### PR TITLE
explicit permissions for release-drafter integration

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Explicit RW permissions for content and pull requests required, due to repository settings, which grants to workflows only read permissions in the repository for the contents and packages scopes.

- RW for content is required for release draft creation (release-drafter).
- RW for pull-requests is required for adding labels to PRs (auto-labeler).