### PR TITLE
enh: Update status in reconcile loop, not in defer

### DIFF
--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -81,11 +81,6 @@ func (r *EtcdClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			Message:            "Cluster initialization has started",
 		})
 	}
-	defer func() {
-		if err := r.Status().Update(ctx, instance); err != nil && !errors.IsConflict(err) {
-			logger.Error(err, "unable to update cluster")
-		}
-	}()
 
 	// check sts condition
 	isClusterReady := false
@@ -99,7 +94,11 @@ func (r *EtcdClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	if err := r.ensureClusterObjects(ctx, instance, isClusterReady); err != nil {
-		return ctrl.Result{}, fmt.Errorf("cannot create Cluster auxiliary objects: %w", err)
+		res, err2 := r.updateStatus(ctx, instance)
+		if err2 != nil {
+			return res, err2
+		}
+		return res, fmt.Errorf("cannot create Cluster auxiliary objects: %w", err)
 	}
 
 	r.updateClusterState(instance, metav1.Condition{
@@ -127,7 +126,7 @@ func (r *EtcdClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		})
 	}
 
-	return ctrl.Result{}, nil
+	return r.updateStatus(ctx, instance)
 }
 
 // ensureClusterObjects creates or updates all objects owned by cluster CR
@@ -472,6 +471,18 @@ func (r *EtcdClusterReconciler) getClusterStateConfigMapName(cluster *etcdaenixi
 
 func (r *EtcdClusterReconciler) getClientServiceName(cluster *etcdaenixiov1alpha1.EtcdCluster) string {
 	return cluster.Name + "-client"
+}
+
+func (r *EtcdClusterReconciler) updateStatus(ctx context.Context, cluster *etcdaenixiov1alpha1.EtcdCluster) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	if err := r.Status().Update(ctx, cluster); err != nil {
+		logger.Error(err, "unable to update cluster status")
+		if errors.IsConflict(err) {
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
 }
 
 // updateClusterState patches status condition in cluster using merge by Type

--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	goerrors "errors"
 	"fmt"
 	"slices"
 
@@ -474,12 +475,9 @@ func (r *EtcdClusterReconciler) getClientServiceName(cluster *etcdaenixiov1alpha
 func (r *EtcdClusterReconciler) updateStatusOnErr(ctx context.Context, cluster *etcdaenixiov1alpha1.EtcdCluster, err error) (ctrl.Result, error) {
 	res, statusErr := r.updateStatus(ctx, cluster)
 	if statusErr != nil {
-		return res, statusErr
+		return res, goerrors.Join(statusErr, err)
 	}
-	if err != nil {
-		return res, fmt.Errorf("cannot create Cluster auxiliary objects: %w", err)
-	}
-	return res, nil
+	return res, err
 }
 
 // updateStatus updates EtcdCluster status and returns error and requeue in case status could not be updated due to conflict


### PR DESCRIPTION
In case error happens during status update request, reconcile will not be requeued. So, this call should be moved ouside `defer` function
fixes #36 