### PR TITLE
fix: use status condition for setting cluster configmap state

### DIFF
--- a/api/v1alpha1/etcdcluster_types.go
+++ b/api/v1alpha1/etcdcluster_types.go
@@ -44,17 +44,19 @@ type EtcdCondType string
 type EtcdCondMessage string
 
 const (
-	EtcdCondTypeInitStarted         EtcdCondType = "InitializationStarted"
-	EtcdCondTypeInitComplete        EtcdCondType = "InitializationComplete"
-	EtcdCondTypeStatefulSetReady    EtcdCondType = "StatefulSetReady"
-	EtcdCondTypeStatefulSetNotReady EtcdCondType = "StatefulSetNotReady"
+	EtcdCondTypeInitStarted           EtcdCondType = "InitializationStarted"
+	EtcdCondTypeInitComplete          EtcdCondType = "InitializationComplete"
+	EtcdCondTypeWaitingForFirstQuorum EtcdCondType = "WaitingForFirstQuorum"
+	EtcdCondTypeStatefulSetReady      EtcdCondType = "StatefulSetReady"
+	EtcdCondTypeStatefulSetNotReady   EtcdCondType = "StatefulSetNotReady"
 )
 
 const (
-	EtcdInitCondNegMessage  EtcdCondMessage = "Cluster initialization started"
-	EtcdInitCondPosMessage  EtcdCondMessage = "Cluster managed resources created"
-	EtcdReadyCondNegMessage EtcdCondMessage = "Cluster StatefulSet is not Ready"
-	EtcdReadyCondPosMessage EtcdCondMessage = "Cluster StatefulSet is Ready"
+	EtcdInitCondNegMessage           EtcdCondMessage = "Cluster initialization started"
+	EtcdInitCondPosMessage           EtcdCondMessage = "Cluster managed resources created"
+	EtcdReadyCondNegMessage          EtcdCondMessage = "Cluster StatefulSet is not Ready"
+	EtcdReadyCondPosMessage          EtcdCondMessage = "Cluster StatefulSet is Ready"
+	EtcdReadyCondNegWaitingForQuorum EtcdCondMessage = "Waiting for first quorum to be established"
 )
 
 // EtcdClusterStatus defines the observed state of EtcdCluster

--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -107,11 +107,11 @@ func (r *EtcdClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 				Complete())
 		}
 	} else {
-		reason := etcdaenixiov1alpha1.EtcdCondTypeStatefulSetReady
-		message := etcdaenixiov1alpha1.EtcdReadyCondPosMessage
-		if !clusterReady {
-			reason = etcdaenixiov1alpha1.EtcdCondTypeStatefulSetNotReady
-			message = etcdaenixiov1alpha1.EtcdReadyCondNegMessage
+		reason := etcdaenixiov1alpha1.EtcdCondTypeStatefulSetNotReady
+		message := etcdaenixiov1alpha1.EtcdReadyCondNegMessage
+		if clusterReady {
+			reason = etcdaenixiov1alpha1.EtcdCondTypeStatefulSetReady
+			message = etcdaenixiov1alpha1.EtcdReadyCondPosMessage
 		}
 
 		factory.SetCondition(instance, factory.NewCondition(etcdaenixiov1alpha1.EtcdConditionReady).

--- a/internal/controller/factory/condition.go
+++ b/internal/controller/factory/condition.go
@@ -69,8 +69,8 @@ func FillConditions(cluster *etcdaenixiov1alpha1.EtcdCluster) {
 		Complete())
 	SetCondition(cluster, NewCondition(etcdaenixiov1alpha1.EtcdConditionReady).
 		WithStatus(false).
-		WithReason(string(etcdaenixiov1alpha1.EtcdCondTypeStatefulSetNotReady)).
-		WithMessage(string(etcdaenixiov1alpha1.EtcdReadyCondNegMessage)).
+		WithReason(string(etcdaenixiov1alpha1.EtcdCondTypeWaitingForFirstQuorum)).
+		WithMessage(string(etcdaenixiov1alpha1.EtcdReadyCondNegWaitingForQuorum)).
 		Complete())
 }
 
@@ -95,4 +95,16 @@ func SetCondition(
 		return
 	}
 	cluster.Status.Conditions[idx] = condition
+}
+
+// GetCondition returns condition from cluster status conditions by type or nil if not present.
+func GetCondition(cluster *etcdaenixiov1alpha1.EtcdCluster, condType string) *metav1.Condition {
+	idx := slices.IndexFunc(cluster.Status.Conditions, func(c metav1.Condition) bool {
+		return c.Type == condType
+	})
+	if idx == -1 {
+		return nil
+	}
+
+	return &cluster.Status.Conditions[idx]
 }


### PR DESCRIPTION
Before that only current statefulset readiness status defined cluster state in configmap.

Checked on local Kind cluster: when using PVC, cluster members can successfully restart without errors. Cluster state in configmap is changed correctly.