### PR TITLE
add pull_request as release-drafter workflow trigger

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,6 +2,7 @@ name: Release Drafter
 
 on:
   workflow_dispatch:
+  pull_request:
   push:
     branches:
       - main
@@ -18,5 +19,6 @@ jobs:
         with:
           disable-releaser: github.ref != 'refs/heads/main'
           config-name: release-drafter.yml
+          commitish: main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,7 +2,7 @@ name: Release Drafter
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
   push:
     branches:
       - main

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,6 +3,11 @@ name: Release Drafter
 on:
   workflow_dispatch:
   pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - unlabeled
   push:
     branches:
       - main


### PR DESCRIPTION
Added `pull_request` event with blank types. By default, a workflow only runs when a `pull_request` event's activity type is `opened`, `synchronize`, or ``reopened`, which should be sufficient.