### PR TITLE
add pull_request_target as release-drafter workflow trigger

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -51,6 +51,7 @@ autolabeler:
   - label: 'dependencies'
     branch:
       - '/deps\/.+/'
+      - '/renovate\/.+/'
   - label: 'documentation'
     files:
       - '**/*.md'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,18 +3,9 @@ name: Release Drafter
 on:
   workflow_dispatch:
   pull_request_target:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - unlabeled
   push:
     branches:
       - main
-
-permissions:
-  contents: write
-  pull-requests: write
 
 jobs:
   update_release_draft:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,6 +2,7 @@ name: Release Drafter
 
 on:
   workflow_dispatch:
+  pull_request:
   push:
     branches:
       - main
@@ -18,5 +19,6 @@ jobs:
         with:
           disable-releaser: github.ref != 'refs/heads/main'
           config-name: release-drafter.yml
+          commitish: main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,7 +2,7 @@ name: Release Drafter
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
   push:
     branches:
       - main

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,6 +3,11 @@ name: Release Drafter
 on:
   workflow_dispatch:
   pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - unlabeled
   push:
     branches:
       - main


### PR DESCRIPTION
Added `pull_request_target` event. Why not `pull_request`:

"Like how the introduction of Cross-Origin Resource Sharing (CORS) in the browser security model allowed a web site developer to relax the default Same Origin Policy (SOP), the introduction of `pull_request_target` trigger allowed a workflow writer to relax some restrictions to a target repository and must be used carefully. The main differences between the two triggers are:

1. Workflows triggered via `pull_request_target` have write permission to the target repository. They also have access to target repository secrets. The same is true for workflows triggered on `pull_request` from a branch in the same repository, but not from external forks. The reasoning behind the latter is that it is safe to share the repository secrets if the user creating the PR has write permission to the target repository already.
2. `pull_request_target` runs in the context of the target repository of the PR, rather than in the merge commit. This means the standard checkout action uses the target repository to prevent accidental usage of the user supplied code.

These safeguards enable granting the `pull_request_target` additional permissions. The reason to introduce the `pull_request_target` trigger was to enable workflows to label PRs (e.g. needs review) or to comment on the PR. The intent is to use the trigger for PRs that do not require dangerous processing, say building or running the content of the PR."

REF: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/