### PR TITLE
Factor out StrategicMerge into a generic function and add a test

### DIFF
--- a/internal/k8sutils/strategicmerge.go
+++ b/internal/k8sutils/strategicmerge.go
@@ -1,0 +1,32 @@
+package k8sutils
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+)
+
+func StrategicMerge[K any](base, patch K) (merged K, err error) {
+	baseBytes, err := json.Marshal(base)
+	if err != nil {
+		return merged, fmt.Errorf("cannot marshal base object to JSON: %w", err)
+	}
+
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return merged, fmt.Errorf("cannot marshal patch object to JSON: %w", err)
+	}
+
+	mergedBytes, err := strategicpatch.StrategicMergePatch(baseBytes, patchBytes, &merged)
+	if err != nil {
+		return merged, fmt.Errorf("cannot patch base pod spec with podTemplate.spec: %w", err)
+	}
+
+	err = json.Unmarshal(mergedBytes, &merged)
+	if err != nil {
+		return merged, fmt.Errorf("cannot unmarshal merged object from JSON: %w", err)
+	}
+
+	return merged, nil
+}

--- a/internal/k8sutils/strategicmerge_test.go
+++ b/internal/k8sutils/strategicmerge_test.go
@@ -1,0 +1,19 @@
+package k8sutils
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("StrategicMerge handler", func() {
+	When("Merging two podspecs", func() {
+		It("Should merge two empty podspecs into an empty podspec", func() {
+			p1 := corev1.PodSpec{}
+			p2 := corev1.PodSpec{}
+			p, err := StrategicMerge(p1, p2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(p).To(Equal(p1))
+		})
+	})
+})

--- a/internal/k8sutils/suite_test.go
+++ b/internal/k8sutils/suite_test.go
@@ -1,0 +1,13 @@
+package k8sutils
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestK8SUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "K8SUtils Suite")
+}


### PR DESCRIPTION
As requested by collaborators in #175 , the `StrategicMergePatch` functionality is factored out into a separate function and a most basic unit test is added to get the ball rolling.