### PR TITLE
fix: download link on getting started page

### DIFF
--- a/site/content/en/docs/v0.2/getting-started/_index.md
+++ b/site/content/en/docs/v0.2/getting-started/_index.md
@@ -14,7 +14,7 @@ Pre-requisites:
 
 1. Install etcd-operator:
     ```bash
-    kubectl apply -f https://github.com/aenix-io/etcd-operator/releases/download/latest/etcd-operator.yaml
+    kubectl apply -f https://github.com/aenix-io/etcd-operator/releases/latest/download/etcd-operator.yaml
     ```
 2. Check the operator is running:
     ```bash


### PR DESCRIPTION
Correct link to install:
https://github.com/aenix-io/etcd-operator/releases/latest/download/etcd-operator.yaml