### PR TITLE
feat: set quota-backend-bytes to 95% of requested size

### DIFF
--- a/internal/controller/factory/statefulset.go
+++ b/internal/controller/factory/statefulset.go
@@ -36,7 +36,8 @@ import (
 )
 
 const (
-	etcdContainerName = "etcd"
+	etcdContainerName                = "etcd"
+	defaultBackendQuotaBytesFraction = 0.95
 )
 
 func CreateOrUpdateStatefulSet(
@@ -259,7 +260,7 @@ func generateEtcdArgs(cluster *etcdaenixiov1alpha1.EtcdCluster) []string {
 		} else {
 			size = *cluster.Spec.Storage.VolumeClaimTemplate.Spec.Resources.Requests.Storage()
 		}
-		quota := float64(size.Value()) * 0.95
+		quota := float64(size.Value()) * defaultBackendQuotaBytesFraction
 		quota = math.Floor(quota)
 		if quota > 0 {
 			if cluster.Spec.Options == nil {


### PR DESCRIPTION
- Changed `ENVTEST_K8S_VERSION` to `1.30.0` as there's no tool chains for version `1.30.1`
- Implemented auto setting `quota-backend-bytes` for requested PVC / emptyDir size

Possible problems:
- After changing requested size, option `quota-backend-bytes` will be left unchanged

fixes #211 
