### PR TITLE
exclude tests from dupl lint check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,9 @@ issues:
       linters:
         - dupl
         - lll
+    - path: _test\.go
+      linters:
+        - dupl
 linters:
   disable-all: true
   enable:


### PR DESCRIPTION
While adding e2e tests we might face to an issue that linter would detect code duplication, despite there would be different test cases.