### PR TITLE
set cosign-installer to use default (latest) cosign version

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -36,8 +36,6 @@ jobs:
       - name: Install cosign
         if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@v3.5.0
-        with:
-          cosign-release: 'v2.1.1'
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache


### PR DESCRIPTION
I'd proceed with using cosign in "keyless" mode, otherwise we'll also need to deal with key management. The root cause of cosign step failures was in rotated TUF root certs: 

- https://github.com/sigstore/cosign/issues/3614#issuecomment-2012521670
- https://blog.sigstore.dev/tuf-root-update/

What about adding verification how-to to README.md: I'd suggest to postpone it until next release, otherwise users might try to verify existing images which will lead to an error:

```
IMG=ghcr.io/aenix-io/etcd-operator:v0.2.0
cosign verify ${IMG} --certificate-identity-regexp '.*' --certificate-oidc-issuer=https://token.actions.githubusercontent.com
Error: no signatures found
main.go:69: error during command execution: no signatures found
```

Fixes: #60 