### PR TITLE
fix: sort etcd args to make them deterministic

### DIFF
--- a/internal/controller/factory/statefulset.go
+++ b/internal/controller/factory/statefulset.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"slices"
 	"strconv"
 
 	"github.com/aenix-io/etcd-operator/internal/log"
@@ -333,6 +334,8 @@ func generateEtcdArgs(cluster *etcdaenixiov1alpha1.EtcdCluster) []string {
 	args = append(args, serverTlsSettings...)
 	args = append(args, clientTlsSettings...)
 	args = append(args, autoCompactionSettings...)
+
+	slices.Sort(args)
 
 	return args
 }

--- a/internal/controller/factory/statefulset_test.go
+++ b/internal/controller/factory/statefulset_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package factory
 
 import (
+	"slices"
+
 	"github.com/google/uuid"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -172,8 +174,17 @@ var _ = Describe("CreateOrUpdateStatefulSet handler", func() {
 				Expect(statefulSet.Spec.Template.ObjectMeta.Annotations).To(Equal(etcdcluster.Spec.PodTemplate.Annotations))
 			})
 
-			By("Checking the extraArgs", func() {
+			By("Checking the command", func() {
 				Expect(statefulSet.Spec.Template.Spec.Containers[0].Command).To(Equal(generateEtcdCommand()))
+			})
+
+			By("Checking the extraArgs", func() {
+				Expect(statefulSet.Spec.Template.Spec.Containers[0].Args).To(Equal(generateEtcdArgs(&etcdcluster)))
+				By("Checking args are sorted", func() {
+					argsClone := slices.Clone(statefulSet.Spec.Template.Spec.Containers[0].Args)
+					slices.Sort(argsClone)
+					Expect(statefulSet.Spec.Template.Spec.Containers[0].Args).To(Equal(argsClone))
+				})
 			})
 
 			By("Checking the readinessGates", func() {


### PR DESCRIPTION
Fix non-deterministic order of etcd args.
fixes #248 