### PR TITLE
add "yq" as a dependency to "generate-docs" in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 .PHONY: generate-docs
-generate-docs: crd-ref-docs ## Generate CRD reference documentation.
+generate-docs: yq crd-ref-docs ## Generate CRD reference documentation.
 	@$(eval VERSION := $(shell $(YQ) '.params.version' site/hugo.yaml))
 	$(CRD_REF_DOCS) --config=.crd-docs.yaml --renderer=markdown --templates-dir="site/reference-templates" --output-path="site/content/en/docs/$(VERSION)/reference/api.md"
 

--- a/site/content/en/docs/v0.4/reference/api.md
+++ b/site/content/en/docs/v0.4/reference/api.md
@@ -167,8 +167,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `minAvailable` _[IntOrString](#intorstring)_ | MinAvailable describes minimum ready replicas. If both are empty, controller will implicitly<br />calculate MaxUnavailable based on number of replicas<br />Mutually exclusive with MaxUnavailable. |  |  |
-| `maxUnavailable` _[IntOrString](#intorstring)_ | MinAvailable describes maximum not ready replicas. If both are empty, controller will implicitly<br />calculate MaxUnavailable based on number of replicas<br />Mutually exclusive with MinAvailable |  |  |
+| `minAvailable` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30.0/#intorstring-intstr-util)_ | MinAvailable describes minimum ready replicas. If both are empty, controller will implicitly<br />calculate MaxUnavailable based on number of replicas<br />Mutually exclusive with MaxUnavailable. |  |  |
+| `maxUnavailable` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30.0/#intorstring-intstr-util)_ | MinAvailable describes maximum not ready replicas. If both are empty, controller will implicitly<br />calculate MaxUnavailable based on number of replicas<br />Mutually exclusive with MinAvailable |  |  |
 
 
 #### PodTemplate


### PR DESCRIPTION
Pre-commit GH actions step can't run successfully without `yq` as a part of the `generate-docs` step in the Makefile. This PR fixes the issue.