### PR TITLE
Add watch verb for storageclasses rbac

### DIFF
--- a/charts/etcd-operator/templates/rbac/clusterrole-manager-role.yml
+++ b/charts/etcd-operator/templates/rbac/clusterrole-manager-role.yml
@@ -73,6 +73,7 @@ rules:
     verbs:
     - get
     - list
+    - watch
   - apiGroups:
       - etcd.aenix.io
     resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -110,3 +110,4 @@ rules:
   verbs:
   - get
   - list
+  - watch

--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -70,7 +70,7 @@ type EtcdClusterReconciler struct {
 // +kubebuilder:rbac:groups="apps",resources=statefulsets,verbs=get;create;delete;update;patch;list;watch
 // +kubebuilder:rbac:groups="policy",resources=poddisruptionbudgets,verbs=get;create;delete;update;patch;list;watch
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;patch;watch
-// +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list
+// +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch
 
 // Reconcile checks CR and current cluster state and performs actions to transform current state to desired.
 func (r *EtcdClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
Fixes these errors: `E0804 17:31:18.410670       1 reflector.go:150] pkg/mod/k8s.io/client-go@v0.30.2/tools/cache/reflector.go:232: Failed to watch *v1.StorageClass: unknown (get storageclasses.storage.k8s.io)`