### PR TITLE
Separate ConfigMap templating and creation

### DIFF
--- a/internal/controller/factory/configmap.go
+++ b/internal/controller/factory/configmap.go
@@ -19,6 +19,7 @@ package factory
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	etcdaenixiov1alpha1 "github.com/aenix-io/etcd-operator/api/v1alpha1"
 	"github.com/aenix-io/etcd-operator/internal/log"
@@ -39,39 +40,16 @@ func CreateOrUpdateClusterStateConfigMap(
 	rclient client.Client,
 ) error {
 	var err error
-	initialCluster := ""
-	clusterService := fmt.Sprintf("%s.%s.svc:2380", GetHeadlessServiceName(cluster), cluster.Namespace)
-	for i := int32(0); i < *cluster.Spec.Replicas; i++ {
-		if i > 0 {
-			initialCluster += ","
-		}
-		podName := fmt.Sprintf("%s-%d", cluster.Name, i)
-		initialCluster += fmt.Sprintf("%s=https://%s.%s",
-			podName, podName, clusterService,
-		)
+	state := "new"
+	if isEtcdClusterReady(cluster) {
+		state = "existing"
 	}
-
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: cluster.Namespace,
-			Name:      GetClusterStateConfigMapName(cluster),
-		},
-		Data: map[string]string{
-			"ETCD_INITIAL_CLUSTER_STATE": "new",
-			"ETCD_INITIAL_CLUSTER":       initialCluster,
-			"ETCD_INITIAL_CLUSTER_TOKEN": cluster.Name + "-" + cluster.Namespace,
-		},
-	}
+	configMap := TemplateClusterStateConfigMap(cluster, state, int(*cluster.Spec.Replicas))
 	ctx, err = contextWithGVK(ctx, configMap, rclient.Scheme())
 	if err != nil {
 		return err
 	}
 
-	if isEtcdClusterReady(cluster) {
-		// update cluster state to existing
-		log.Debug(ctx, "updating cluster state")
-		configMap.Data["ETCD_INITIAL_CLUSTER_STATE"] = "existing"
-	}
 	log.Debug(ctx, "configmap data generated", "data", configMap.Data)
 
 	if err := ctrl.SetControllerReference(cluster, configMap, rclient.Scheme()); err != nil {
@@ -87,4 +65,33 @@ func isEtcdClusterReady(cluster *etcdaenixiov1alpha1.EtcdCluster) bool {
 	cond := meta.FindStatusCondition(cluster.Status.Conditions, etcdaenixiov1alpha1.EtcdConditionReady)
 	return cond != nil && (cond.Reason == string(etcdaenixiov1alpha1.EtcdCondTypeStatefulSetReady) ||
 		cond.Reason == string(etcdaenixiov1alpha1.EtcdCondTypeStatefulSetNotReady))
+}
+func TemplateClusterStateConfigMap(cluster *etcdaenixiov1alpha1.EtcdCluster, state string, replicas int) *corev1.ConfigMap {
+
+	initialClusterMembers := make([]string, replicas)
+	clusterService := fmt.Sprintf("%s.%s.svc:2380", GetHeadlessServiceName(cluster), cluster.Namespace)
+	for i := 0; i < replicas; i++ {
+		podName := fmt.Sprintf("%s-%d", cluster.Name, i)
+		initialClusterMembers[i] = fmt.Sprintf("%s=https://%s.%s",
+			podName, podName, clusterService,
+		)
+	}
+	initialCluster := strings.Join(initialClusterMembers, ",")
+
+	configMap := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-cluster-state", cluster.Name),
+			Namespace: cluster.Namespace,
+		},
+		Data: map[string]string{
+			"ETCD_INITIAL_CLUSTER_STATE": state,
+			"ETCD_INITIAL_CLUSTER":       initialCluster,
+			"ETCD_INITIAL_CLUSTER_TOKEN": fmt.Sprintf("%s-%s", cluster.Name, cluster.Namespace),
+		},
+	}
+	return configMap
 }


### PR DESCRIPTION
This PR is part of a stacked pull request on top of #252. The big picture is documented in #181 and #207.

This commit factors out the building of a corev1.ConfigMap struct into a separate function, while leaving the logic of determining key parameters, such as the initial cluster, state, etc, as well as sending the request to the k8s API server in the already existing CreateOrUpdate function. This will be useful in the future, when this logic will be moved out of the factory library and into the reconciliation loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved modularity and clarity in cluster state management with the introduction of a new helper function for creating configuration maps.
  
- **Refactor**
	- Simplified the `CreateOrUpdateClusterStateConfigMap` function for better readability and maintainability by delegating the configuration map creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->