### PR TITLE
wait for client cert to become ready before getting etcd client

### DIFF
--- a/examples/manifests/etcdcluster-with-external-certificates.yaml
+++ b/examples/manifests/etcdcluster-with-external-certificates.yaml
@@ -44,7 +44,7 @@ spec:
   secretName: ca-peer-secret
   privateKey:
     algorithm: RSA
-    size: 4096
+    size: 2048
   issuerRef:
     name: selfsigned-issuer
     kind: Issuer
@@ -70,7 +70,7 @@ spec:
   secretName: ca-server-secret
   privateKey:
     algorithm: RSA
-    size: 4096
+    size: 2048
   issuerRef:
     name: selfsigned-issuer
     kind: Issuer
@@ -96,7 +96,7 @@ spec:
   secretName: ca-client-secret
   privateKey:
     algorithm: RSA
-    size: 4096
+    size: 2048
   issuerRef:
     name: selfsigned-issuer
     kind: Issuer
@@ -162,7 +162,7 @@ spec:
   privateKey:
     rotationPolicy: Always
     algorithm: RSA
-    size: 4096
+    size: 2048
   issuerRef:
     name: ca-issuer-server
 ---
@@ -197,7 +197,7 @@ spec:
   privateKey:
     rotationPolicy: Always
     algorithm: RSA
-    size: 4096
+    size: 2048
   issuerRef:
     name: ca-issuer-peer
 ---
@@ -216,7 +216,7 @@ spec:
   privateKey:
     rotationPolicy: Always
     algorithm: RSA
-    size: 4096
+    size: 2048
   issuerRef:
     name: ca-issuer-client
     kind: Issuer

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -224,6 +224,17 @@ allowVolumeExpansion: true
 
 			Eventually(func() error {
 				cmd := exec.Command("kubectl", "wait",
+					"certificate/client-certificate",
+					"--for", "condition=Ready",
+					"--namespace", namespace,
+					"--timeout", "5m",
+				)
+				_, err = utils.Run(cmd)
+				return err
+			}, time.Second*20, time.Second*2).Should(Succeed(), "wait for client cert ready")
+
+			Eventually(func() error {
+				cmd := exec.Command("kubectl", "wait",
 					"statefulset/test",
 					"--for", "jsonpath={.status.availableReplicas}=3",
 					"--namespace", namespace,


### PR DESCRIPTION
The test of etcd cluster with TLS and auth config fails frequently, because the client certificate does not get created, before the etcd cluster is up and running. This PR adds a step to wait for the client cert to become ready, before executing the rest of the tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Reduced RSA private key sizes for various certificates to enhance security.
	- Added a new end-to-end test case to ensure readiness of TLS client certificates before proceeding with cluster operations.

- **Bug Fixes**
	- Improved test reliability by ensuring TLS certificates are ready before stateful set readiness checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->