### PR TITLE
add option to trigger release-assets workflow manually

### DIFF
--- a/.github/workflows/release-assets.yaml
+++ b/.github/workflows/release-assets.yaml
@@ -4,6 +4,8 @@ on:
     types:
       - created
 
+  workflow_dispatch:
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}


### PR DESCRIPTION
Release v0.4.1 did not trigger creation of assets, hence documentation is not consistent with the state of the release:

> 1. Install etcd-operator:
> 
> `kubectl apply -f https://github.com/aenix-io/etcd-operator/releases/latest/download/etcd-operator.yaml`

but the etcd-operator.yaml does not exists for release v0.4.1 (latest)

To solve this bug, we can manually trigger the workflow targeting it to the tag v0.4.1.

Fixes: #263 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced GitHub Actions workflow by adding manual trigger capability
	- Improved workflow flexibility for release asset generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->