### PR TITLE
feature/add-vpa

### DIFF
--- a/charts/etcd-operator/README.md
+++ b/charts/etcd-operator/README.md
@@ -26,6 +26,11 @@
 | etcdOperator.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}` | ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
 | etcdOperator.service.port | int | `9443` | Service port |
 | etcdOperator.service.type | string | `"ClusterIP"` | Service type |
+| etcdOperator.vpa.enabled | bool | `true` |  |
+| etcdOperator.vpa.maxAllowed.cpu | int | `1` |  |
+| etcdOperator.vpa.maxAllowed.memory | string | `"1Gi"` |  |
+| etcdOperator.vpa.minAllowed.cpu | string | `"100m"` |  |
+| etcdOperator.vpa.minAllowed.memory | string | `"128Mi"` |  |
 | fullnameOverride | string | `""` | Override a full name of helm release |
 | imagePullSecrets | list | `[]` |  |
 | kubeRbacProxy.args[0] | string | `"--secure-listen-address=0.0.0.0:8443"` |  |
@@ -41,6 +46,11 @@
 | kubeRbacProxy.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}` | ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
 | kubeRbacProxy.service.port | int | `8443` | Service port |
 | kubeRbacProxy.service.type | string | `"ClusterIP"` | Service type |
+| kubeRbacProxy.vpa.enabled | bool | `true` |  |
+| kubeRbacProxy.vpa.maxAllowed.cpu | string | `"500m"` |  |
+| kubeRbacProxy.vpa.maxAllowed.memory | string | `"256Mi"` |  |
+| kubeRbacProxy.vpa.minAllowed.cpu | string | `"50m"` |  |
+| kubeRbacProxy.vpa.minAllowed.memory | string | `"64Mi"` |  |
 | kubernetesClusterDomain | string | `"cluster.local"` | Kubernetes cluster domain prefix |
 | nameOverride | string | `""` | Override a name of helm release |
 | nodeSelector | object | `{}` | ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/ |
@@ -51,4 +61,5 @@
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | tolerations | list | `[]` | ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
+| vpa.updatePolicy | string | `"Auto"` |  |
 

--- a/charts/etcd-operator/README.md
+++ b/charts/etcd-operator/README.md
@@ -27,7 +27,7 @@
 | etcdOperator.service.port | int | `9443` | Service port |
 | etcdOperator.service.type | string | `"ClusterIP"` | Service type |
 | etcdOperator.vpa.enabled | bool | `true` |  |
-| etcdOperator.vpa.maxAllowed.cpu | int | `1` |  |
+| etcdOperator.vpa.maxAllowed.cpu | string | `"1000m"` |  |
 | etcdOperator.vpa.maxAllowed.memory | string | `"1Gi"` |  |
 | etcdOperator.vpa.minAllowed.cpu | string | `"100m"` |  |
 | etcdOperator.vpa.minAllowed.memory | string | `"128Mi"` |  |

--- a/charts/etcd-operator/templates/workload/deployment.yml
+++ b/charts/etcd-operator/templates/workload/deployment.yml
@@ -45,9 +45,11 @@ spec:
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if not .Values.etcdOperator.vpa.enabled }}
           {{- with .Values.etcdOperator.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- end }}
           {{- with .Values.etcdOperator.securityContext }}
           securityContext:
@@ -87,9 +89,11 @@ spec:
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if not .Values.kubeRbacProxy.vpa.enabled }}
           {{- with .Values.kubeRbacProxy.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- end }}
           {{- with .Values.kubeRbacProxy.securityContext }}
           securityContext:

--- a/charts/etcd-operator/templates/workload/vpa.yml
+++ b/charts/etcd-operator/templates/workload/vpa.yml
@@ -1,0 +1,41 @@
+{{- if or .Values.etcdOperator.vpa.enabled .Values.kubeRbacProxy.vpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "etcd-operator.fullname" . }}-controller-manager
+  labels:
+    {{- include "etcd-operator.labels" . | nindent 4 }}
+spec:
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: Deployment
+    name: {{ include "etcd-operator.fullname" . }}-controller-manager
+  updatePolicy:
+    updateMode: {{ .Values.vpa.updatePolicy | default "Auto" | quote }}
+  resourcePolicy:
+    containerPolicies:
+    {{- if .Values.etcdOperator.vpa.enabled }}
+      - containerName: etcd-operator
+        {{- with .Values.etcdOperator.vpa.minAllowed }}
+        minAllowed:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.etcdOperator.vpa.maxAllowed }}
+        maxAllowed:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        controlledResources: ["cpu", "memory"]
+    {{- end }}
+    {{- if .Values.kubeRbacProxy.vpa.enabled }}
+      - containerName: kube-rbac-proxy
+        {{- with .Values.kubeRbacProxy.vpa.minAllowed }}
+        minAllowed:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.kubeRbacProxy.vpa.maxAllowed }}
+        maxAllowed:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        controlledResources: ["cpu", "memory"]
+    {{- end }}
+{{- end }}

--- a/charts/etcd-operator/values.schema.json
+++ b/charts/etcd-operator/values.schema.json
@@ -131,6 +131,36 @@
                         }
                     },
                     "type": "object"
+                },
+                "vpa": {
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "maxAllowed": {
+                            "properties": {
+                                "cpu": {
+                                    "type": "integer"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "minAllowed": {
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
                 }
             },
             "type": "object"
@@ -227,6 +257,36 @@
                         }
                     },
                     "type": "object"
+                },
+                "vpa": {
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "maxAllowed": {
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        "minAllowed": {
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
                 }
             },
             "type": "object"
@@ -270,6 +330,14 @@
         },
         "tolerations": {
             "type": "array"
+        },
+        "vpa": {
+            "properties": {
+                "updatePolicy": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
         }
     },
     "type": "object"

--- a/charts/etcd-operator/values.schema.json
+++ b/charts/etcd-operator/values.schema.json
@@ -140,7 +140,7 @@
                         "maxAllowed": {
                             "properties": {
                                 "cpu": {
-                                    "type": "integer"
+                                    "type": "string"
                                 },
                                 "memory": {
                                     "type": "string"

--- a/charts/etcd-operator/values.yaml
+++ b/charts/etcd-operator/values.yaml
@@ -90,7 +90,7 @@ etcdOperator:
       cpu: 100m
       memory: 128Mi
     maxAllowed:
-      cpu: 1
+      cpu: 1000m
       memory: 1Gi
 
 kubeRbacProxy:

--- a/charts/etcd-operator/values.yaml
+++ b/charts/etcd-operator/values.yaml
@@ -84,6 +84,15 @@ etcdOperator:
       drop:
         - ALL
 
+  vpa:
+    enabled: true
+    minAllowed:
+      cpu: 100m
+      memory: 128Mi
+    maxAllowed:
+      cpu: 1
+      memory: 1Gi
+
 kubeRbacProxy:
 
   image:
@@ -142,6 +151,15 @@ kubeRbacProxy:
       drop:
           - ALL
 
+  vpa:
+    enabled: true
+    minAllowed:
+      cpu: 50m
+      memory: 64Mi
+    maxAllowed:
+      cpu: 500m
+      memory: 256Mi
+
 # -- Kubernetes cluster domain prefix
 kubernetesClusterDomain: cluster.local
 
@@ -182,3 +200,6 @@ tolerations: []
 
 # -- ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
+
+vpa:
+  updatePolicy: "Auto"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced Vertical Pod Autoscaler (VPA) support for etcd-operator and kube-rbac-proxy, enabling automatic resource scaling based on configurable limits.
  - Added new configuration options to control VPA enablement, resource constraints, and update policy directly from the values file.

- **Chores**
  - Updated deployment templates to conditionally exclude resource settings when VPA is enabled.
  - Enhanced documentation with VPA configuration details and updated schema to validate new VPA settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->