### PR TITLE
Bugs: wrong address and memory leak

### DIFF
--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -113,10 +113,12 @@ func (r *EtcdClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 	defer func() {
 		if clusterClient != nil {
+			// nolint:errcheck
 			clusterClient.Close()
 		}
 		for i := range singleClients {
 			if singleClients[i] != nil {
+				// nolint:errcheck
 				singleClients[i].Close()
 			}
 		}
@@ -296,6 +298,8 @@ func (r *EtcdClusterReconciler) ensureConditionalClusterObjects(
 }
 
 // updateStatusOnErr wraps error and updates EtcdCluster status
+// TODO: refactor this so the linter doesn't complain
+// nolint:unparam
 func (r *EtcdClusterReconciler) updateStatusOnErr(ctx context.Context, cluster *etcdaenixiov1alpha1.EtcdCluster, err error) (ctrl.Result, error) {
 	// The function 'updateStatusOnErr' will always return non-nil error. Hence, the ctrl.Result will always be ignored.
 	// Therefore, the ctrl.Result returned by 'updateStatus' function can be discarded.
@@ -351,9 +355,8 @@ func (r *EtcdClusterReconciler) configureAuth(ctx context.Context, cluster *etcd
 		return err
 	}
 
-	defer func() {
-		err = cli.Close()
-	}()
+	// nolint:errcheck
+	defer cli.Close()
 
 	err = testMemberList(ctx, cli)
 	if err != nil {

--- a/internal/controller/etcdcluster_controller.go
+++ b/internal/controller/etcdcluster_controller.go
@@ -111,6 +111,16 @@ func (r *EtcdClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+	defer func() {
+		if clusterClient != nil {
+			clusterClient.Close()
+		}
+		for i := range singleClients {
+			if singleClients[i] != nil {
+				singleClients[i].Close()
+			}
+		}
+	}()
 	state.endpointsFound = clusterClient != nil && singleClients != nil
 
 	if !state.endpointsFound {

--- a/internal/controller/factory/etcd_client.go
+++ b/internal/controller/factory/etcd_client.go
@@ -29,6 +29,7 @@ func NewEtcdClientSet(ctx context.Context, cluster *v1alpha1.EtcdCluster, cli cl
 		cfg.Endpoints = []string{ep}
 		singleClients[i], err = clientv3.New(cfg)
 		if err != nil {
+			clusterClient.Close()
 			return nil, nil, fmt.Errorf("error building etcd single-endpoint client for endpoint %s: %w", ep, err)
 		}
 	}
@@ -56,7 +57,7 @@ func configFromCluster(ctx context.Context, cluster *v1alpha1.EtcdCluster, cli c
 		}
 	}
 	for name := range names {
-		urls = append(urls, fmt.Sprintf("%s:%s", name, "2379"))
+		urls = append(urls, fmt.Sprintf("%s.%s.%s:%s", name, ep.Name, ep.Namespace, "2379"))
 	}
 
 	return clientv3.Config{Endpoints: urls}, nil

--- a/internal/controller/factory/etcd_client.go
+++ b/internal/controller/factory/etcd_client.go
@@ -33,6 +33,7 @@ func NewEtcdClientSet(ctx context.Context, cluster *v1alpha1.EtcdCluster, cli cl
 		cfg.Endpoints = []string{ep}
 		singleClients[i], err = clientv3.New(cfg)
 		if err != nil {
+			// nolint:errcheck
 			clusterClient.Close()
 			return nil, nil, fmt.Errorf("error building etcd single-endpoint client for endpoint %s: %w", ep, err)
 		}


### PR DESCRIPTION
* We create several etcd clients in the reconciliation loop, but never had a defer .Close() for them.
* We erroneously try to configure these clients with etcd-0 instead of etcd-0.etcd-headless.namespace as the url.

Now fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resource cleanup by ensuring all etcd client connections are properly closed, preventing potential resource leaks.

- **New Features**
  - Added support for TLS client authentication using certificates and CA secrets for enhanced security.
  - Set a default connection timeout to improve reliability.

- **Refactor**
  - Updated endpoint addressing to use fully qualified domain names for improved accuracy and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->