### PR TITLE
Update kamaji example

### DIFF
--- a/examples/manifests/etcdcluster-kamaji.yaml
+++ b/examples/manifests/etcdcluster-kamaji.yaml
@@ -135,6 +135,7 @@ spec:
   secretName: etcd-server-tls
   isCA: false
   usages:
+    - "client auth"
     - "server auth"
     - "signing"
     - "key encipherment"


### PR DESCRIPTION
According to this [issue comment](https://github.com/etcd-io/etcd/issues/9785#issuecomment-432438748) etcd uses server cert for self-monitoring. Thus, "client auth" usage in server cert is required, otherwise there are warnings in logs:

```
2025/08/28 03:35:22 WARNING: [core] [Channel #3 SubChannel #4] grpc: addrConn.createTransport failed to connect to {Addr: "0.0.0.0:2379", ServerName: "0.0.0.0:2379", }. Err: connection error: desc = "error reading server preface: remote error: tls: bad certificate"
```

Updated etcdcluster-kamaji.yaml to address this problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the etcd-server certificate in the Kamaji example manifest to include client authentication in key usages. This improves TLS handshakes, prevents client auth errors, and enhances compatibility with tools and components that require mutual TLS. No other certificate fields were modified, ensuring no breaking changes. Users should experience smoother setup and connectivity when deploying the example manifest with components that expect client authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->