### PR TITLE
moved 127.0.0.1 to ipAddresses

### DIFF
--- a/examples/manifests/etcdcluster-kamaji.yaml
+++ b/examples/manifests/etcdcluster-kamaji.yaml
@@ -140,20 +140,21 @@ spec:
     - "signing"
     - "key encipherment"
   dnsNames:
-  - etcd-0
-  - etcd-0.etcd-headless
-  - etcd-0.etcd-headless.kamaji-system.svc
-  - etcd-0.etcd-headless.kamaji-system.svc.cluster.local
-  - etcd-1
-  - etcd-1.etcd-headless
-  - etcd-1.etcd-headless.kamaji-system.svc
-  - etcd-1.etcd-headless.kamaji-system.svc.cluster.local
-  - etcd-2
-  - etcd-2.etcd-headless
-  - etcd-2.etcd-headless.kamaji-system.svc
-  - etcd-2.etcd-headless.kamaji-system.svc.cluster.local
-  - localhost
-  - "127.0.0.1"
+    - etcd-0
+    - etcd-0.etcd-headless
+    - etcd-0.etcd-headless.kamaji-system.svc
+    - etcd-0.etcd-headless.kamaji-system.svc.cluster.local
+    - etcd-1
+    - etcd-1.etcd-headless
+    - etcd-1.etcd-headless.kamaji-system.svc
+    - etcd-1.etcd-headless.kamaji-system.svc.cluster.local
+    - etcd-2
+    - etcd-2.etcd-headless
+    - etcd-2.etcd-headless.kamaji-system.svc
+    - etcd-2.etcd-headless.kamaji-system.svc.cluster.local
+    - localhost
+  ipAddresses:
+    - 127.0.0.1
   privateKey:
     rotationPolicy: Always
     algorithm: RSA

--- a/examples/manifests/etcdcluster-kamaji.yaml
+++ b/examples/manifests/etcdcluster-kamaji.yaml
@@ -140,21 +140,21 @@ spec:
     - "signing"
     - "key encipherment"
   dnsNames:
-    - etcd-0
-    - etcd-0.etcd-headless
-    - etcd-0.etcd-headless.kamaji-system.svc
-    - etcd-0.etcd-headless.kamaji-system.svc.cluster.local
-    - etcd-1
-    - etcd-1.etcd-headless
-    - etcd-1.etcd-headless.kamaji-system.svc
-    - etcd-1.etcd-headless.kamaji-system.svc.cluster.local
-    - etcd-2
-    - etcd-2.etcd-headless
-    - etcd-2.etcd-headless.kamaji-system.svc
-    - etcd-2.etcd-headless.kamaji-system.svc.cluster.local
-    - localhost
+  - etcd-0
+  - etcd-0.etcd-headless
+  - etcd-0.etcd-headless.kamaji-system.svc
+  - etcd-0.etcd-headless.kamaji-system.svc.cluster.local
+  - etcd-1
+  - etcd-1.etcd-headless
+  - etcd-1.etcd-headless.kamaji-system.svc
+  - etcd-1.etcd-headless.kamaji-system.svc.cluster.local
+  - etcd-2
+  - etcd-2.etcd-headless
+  - etcd-2.etcd-headless.kamaji-system.svc
+  - etcd-2.etcd-headless.kamaji-system.svc.cluster.local
+  - localhost
   ipAddresses:
-    - 127.0.0.1
+  - 127.0.0.1
   privateKey:
     rotationPolicy: Always
     algorithm: RSA


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected etcd-server certificate SANs so the loopback address is treated as an IP (IP SAN) rather than a DNS name, improving certificate validation and TLS connectivity for etcd services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->