### PR TITLE
chore(api): rename group to etcd-operator.cozystack.io and module to cozystack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,9 +139,9 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize-$(KUSTOMIZE_VERSION)
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen-$(CONTROLLER_TOOLS_VERSION)
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 
-# go-install-tool installs $2@$3 under $1. Pattern stolen from
-# lllamnyp/operator. `go install` drops the binary at $LOCALBIN/<basename>,
-# so we rename it after install to the version-suffixed target path.
+# go-install-tool installs $2@$3 under $1. `go install` drops the binary at
+# $LOCALBIN/<basename>, so we rename it after install to the version-suffixed
+# target path.
 define go-install-tool
 @[ -f $(1) ] || { \
 set -e; \

--- a/PROJECT
+++ b/PROJECT
@@ -2,26 +2,26 @@
 # This file is used to track the info used to scaffold your project
 # and allow the plugins properly work.
 # More info: https://book.kubebuilder.io/reference/project-config.html
-domain: lllamnyp.su
+domain: etcd-operator.cozystack.io
 layout:
 - go.kubebuilder.io/v4
 projectName: etcd-operator
-repo: github.com/lllamnyp/etcd-operator
+repo: github.com/cozystack/etcd-operator
 resources:
 - api:
     crdVersion: v1
     namespaced: true
   controller: true
-  domain: lllamnyp.su
+  domain: etcd-operator.cozystack.io
   kind: EtcdCluster
-  path: github.com/lllamnyp/etcd-operator/api/v1alpha2
+  path: github.com/cozystack/etcd-operator/api/v1alpha2
   version: v1alpha2
 - api:
     crdVersion: v1
     namespaced: true
   controller: true
-  domain: lllamnyp.su
+  domain: etcd-operator.cozystack.io
   kind: EtcdMember
-  path: github.com/lllamnyp/etcd-operator/api/v1alpha2
+  path: github.com/cozystack/etcd-operator/api/v1alpha2
   version: v1alpha2
 version: "3"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # etcd-operator
 
-A Kubernetes operator for running [etcd](https://etcd.io/) clusters. Status: **early alpha** — API is `lllamnyp.su/v1alpha2` and will likely change.
+A Kubernetes operator for running [etcd](https://etcd.io/) clusters. Status: **early alpha** — API is `etcd-operator.cozystack.io/v1alpha2` and will likely change.
 
 ## What it does
 
@@ -45,7 +45,7 @@ make docker-build docker-push deploy IMG=<your-registry>/etcd-operator:<tag>
 
 # 2. Create a cluster.
 cat <<'EOF' | kubectl apply -f -
-apiVersion: lllamnyp.su/v1alpha2
+apiVersion: etcd-operator.cozystack.io/v1alpha2
 kind: EtcdCluster
 metadata:
   name: my-etcd
@@ -58,8 +58,8 @@ spec:
 EOF
 
 # 3. Wait for ready and inspect.
-kubectl get etcdcluster.lllamnyp.su my-etcd -w
-POD=$(kubectl get pod -l etcd.lllamnyp.su/cluster=my-etcd \
+kubectl get etcdcluster.etcd-operator.cozystack.io my-etcd -w
+POD=$(kubectl get pod -l etcd-operator.cozystack.io/cluster=my-etcd \
   -o jsonpath='{.items[0].metadata.name}')
 kubectl exec -it "$POD" -- etcdctl --endpoints=http://localhost:2379 \
   member list -w table

--- a/api/v1alpha2/cel_validation_test.go
+++ b/api/v1alpha2/cel_validation_test.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	lll "github.com/lllamnyp/etcd-operator/api/v1alpha2"
+	lll "github.com/cozystack/etcd-operator/api/v1alpha2"
 )
 
 // The four CEL XValidation rules on EtcdClusterSpec, end-to-end against
@@ -172,7 +172,7 @@ func TestCEL_StorageMustBeNonZero_IntegerInput(t *testing.T) {
 
 	u := &unstructured.Unstructured{}
 	u.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "lllamnyp.su",
+		Group:   "etcd-operator.cozystack.io",
 		Version: "v1alpha2",
 		Kind:    "EtcdCluster",
 	})

--- a/api/v1alpha2/etcdcluster_types.go
+++ b/api/v1alpha2/etcdcluster_types.go
@@ -211,7 +211,7 @@ const (
 // Production memory clusters also want hard pod-anti-affinity and a
 // container memory limit covering the tmpfs size plus etcd's own
 // headroom. Those two are not auto-emitted by the operator yet — see
-// https://github.com/lllamnyp/etcd-operator/issues/16. The
+// https://github.com/cozystack/etcd-operator/issues/16. The
 // PodDisruptionBudget is auto-emitted on every cluster.
 //
 // +kubebuilder:validation:Enum="";Memory
@@ -387,7 +387,7 @@ type EtcdClusterStatus struct {
 	// "current scale" without a custom status field.
 	ReadyMembers int32 `json:"readyMembers,omitempty"`
 
-	// Selector is the label-selector form ("etcd.lllamnyp.su/cluster=<name>")
+	// Selector is the label-selector form ("etcd-operator.cozystack.io/cluster=<name>")
 	// matching every Pod owned by this cluster. Surfaced for the /scale
 	// subresource — the VPA admission controller reads it via Scales().Get()
 	// to know which Pods to inject recommendations into. Plain users won't

--- a/api/v1alpha2/groupversion_info.go
+++ b/api/v1alpha2/groupversion_info.go
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1alpha2 contains API Schema definitions for the  v1alpha2 API group
+// Package v1alpha2 contains API Schema definitions for the v1alpha2 API group.
+//
+// There is intentionally no v1alpha1 under etcd-operator.cozystack.io: the
+// version was carried over unchanged when the group was renamed from the
+// previous identity, so the new group starts at v1alpha2.
 // +kubebuilder:object:generate=true
 // +groupName=etcd-operator.cozystack.io
 package v1alpha2

--- a/api/v1alpha2/groupversion_info.go
+++ b/api/v1alpha2/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1alpha2 contains API Schema definitions for the  v1alpha2 API group
 // +kubebuilder:object:generate=true
-// +groupName=lllamnyp.su
+// +groupName=etcd-operator.cozystack.io
 package v1alpha2
 
 import (
@@ -26,7 +26,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "lllamnyp.su", Version: "v1alpha2"}
+	GroupVersion = schema.GroupVersion{Group: "etcd-operator.cozystack.io", Version: "v1alpha2"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/api/v1alpha2/validation_envtest_test.go
+++ b/api/v1alpha2/validation_envtest_test.go
@@ -25,7 +25,7 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
-	lll "github.com/lllamnyp/etcd-operator/api/v1alpha2"
+	lll "github.com/cozystack/etcd-operator/api/v1alpha2"
 )
 
 // envtest harness for CEL CRD validation rules. CEL XValidation is

--- a/config/crd/bases/etcd-operator.cozystack.io_etcdclusters.yaml
+++ b/config/crd/bases/etcd-operator.cozystack.io_etcdclusters.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: etcdclusters.lllamnyp.su
+  name: etcdclusters.etcd-operator.cozystack.io
 spec:
-  group: lllamnyp.su
+  group: etcd-operator.cozystack.io
   names:
     kind: EtcdCluster
     listKind: EtcdClusterList
@@ -703,7 +703,7 @@ spec:
                 type: integer
               selector:
                 description: |-
-                  Selector is the label-selector form ("etcd.lllamnyp.su/cluster=<name>")
+                  Selector is the label-selector form ("etcd-operator.cozystack.io/cluster=<name>")
                   matching every Pod owned by this cluster. Surfaced for the /scale
                   subresource — the VPA admission controller reads it via Scales().Get()
                   to know which Pods to inject recommendations into. Plain users won't

--- a/config/crd/bases/etcd-operator.cozystack.io_etcdmembers.yaml
+++ b/config/crd/bases/etcd-operator.cozystack.io_etcdmembers.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
-  name: etcdmembers.lllamnyp.su
+  name: etcdmembers.etcd-operator.cozystack.io
 spec:
-  group: lllamnyp.su
+  group: etcd-operator.cozystack.io
   names:
     kind: EtcdMember
     listKind: EtcdMemberList

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,8 +2,8 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/lllamnyp.su_etcdclusters.yaml
-- bases/lllamnyp.su_etcdmembers.yaml
+- bases/etcd-operator.cozystack.io_etcdclusters.yaml
+- bases/etcd-operator.cozystack.io_etcdmembers.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:

--- a/config/crd/patches/cainjection_in_etcdclusters.yaml
+++ b/config/crd/patches/cainjection_in_etcdclusters.yaml
@@ -4,4 +4,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: etcdclusters.lllamnyp.su
+  name: etcdclusters.etcd-operator.cozystack.io

--- a/config/crd/patches/webhook_in_etcdclusters.yaml
+++ b/config/crd/patches/webhook_in_etcdclusters.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: etcdclusters.lllamnyp.su
+  name: etcdclusters.etcd-operator.cozystack.io
 spec:
   conversion:
     strategy: Webhook

--- a/config/rbac/etcdcluster_editor_role.yaml
+++ b/config/rbac/etcdcluster_editor_role.yaml
@@ -12,7 +12,7 @@ metadata:
   name: etcdcluster-editor-role
 rules:
 - apiGroups:
-  - lllamnyp.su
+  - etcd-operator.cozystack.io
   resources:
   - etcdclusters
   verbs:
@@ -24,7 +24,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - lllamnyp.su
+  - etcd-operator.cozystack.io
   resources:
   - etcdclusters/status
   verbs:

--- a/config/rbac/etcdcluster_viewer_role.yaml
+++ b/config/rbac/etcdcluster_viewer_role.yaml
@@ -12,7 +12,7 @@ metadata:
   name: etcdcluster-viewer-role
 rules:
 - apiGroups:
-  - lllamnyp.su
+  - etcd-operator.cozystack.io
   resources:
   - etcdclusters
   verbs:
@@ -20,7 +20,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - lllamnyp.su
+  - etcd-operator.cozystack.io
   resources:
   - etcdclusters/status
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -58,7 +58,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - lllamnyp.su
+  - etcd-operator.cozystack.io
   resources:
   - etcdclusters
   verbs:
@@ -66,14 +66,14 @@ rules:
   - list
   - watch
 - apiGroups:
-  - lllamnyp.su
+  - etcd-operator.cozystack.io
   resources:
   - etcdclusters/finalizers
   - etcdmembers/finalizers
   verbs:
   - update
 - apiGroups:
-  - lllamnyp.su
+  - etcd-operator.cozystack.io
   resources:
   - etcdclusters/status
   - etcdmembers/status
@@ -82,7 +82,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - lllamnyp.su
+  - etcd-operator.cozystack.io
   resources:
   - etcdmembers
   verbs:

--- a/config/samples/_v1alpha2_etcdcluster.yaml
+++ b/config/samples/_v1alpha2_etcdcluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: lllamnyp.su/v1alpha2
+apiVersion: etcd-operator.cozystack.io/v1alpha2
 kind: EtcdCluster
 metadata:
   name: etcdcluster-sample

--- a/controllers/etcd_client.go
+++ b/controllers/etcd_client.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	lll "github.com/lllamnyp/etcd-operator/api/v1alpha2"
+	lll "github.com/cozystack/etcd-operator/api/v1alpha2"
 )
 
 // EtcdClusterClient is the subset of the etcd v3 client used by the operator.

--- a/controllers/etcdcluster_controller.go
+++ b/controllers/etcdcluster_controller.go
@@ -40,7 +40,7 @@ import (
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 
-	lll "github.com/lllamnyp/etcd-operator/api/v1alpha2"
+	lll "github.com/cozystack/etcd-operator/api/v1alpha2"
 )
 
 // DefaultProgressDeadlineSeconds is used when the user doesn't set one.
@@ -75,11 +75,11 @@ type EtcdClusterReconciler struct {
 	ClusterDomain string
 }
 
-//+kubebuilder:rbac:groups=lllamnyp.su,resources=etcdclusters,verbs=get;list;watch
-//+kubebuilder:rbac:groups=lllamnyp.su,resources=etcdclusters/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=lllamnyp.su,resources=etcdclusters/finalizers,verbs=update
-//+kubebuilder:rbac:groups=lllamnyp.su,resources=etcdmembers,verbs=get;list;watch;create;delete
-//+kubebuilder:rbac:groups=lllamnyp.su,resources=etcdmembers/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=etcd-operator.cozystack.io,resources=etcdclusters,verbs=get;list;watch
+//+kubebuilder:rbac:groups=etcd-operator.cozystack.io,resources=etcdclusters/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=etcd-operator.cozystack.io,resources=etcdclusters/finalizers,verbs=update
+//+kubebuilder:rbac:groups=etcd-operator.cozystack.io,resources=etcdmembers,verbs=get;list;watch;create;delete
+//+kubebuilder:rbac:groups=etcd-operator.cozystack.io,resources=etcdmembers/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch
 //+kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch

--- a/controllers/etcdcluster_controller_test.go
+++ b/controllers/etcdcluster_controller_test.go
@@ -33,7 +33,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	lll "github.com/lllamnyp/etcd-operator/api/v1alpha2"
+	lll "github.com/cozystack/etcd-operator/api/v1alpha2"
 )
 
 // reconcileUntilStable drives a reconciler in a loop until it stops requesting
@@ -505,7 +505,7 @@ func TestScaleUp_AdoptsPendingCRAndRetriesAdd(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-pndng", Namespace: "ns", Labels: clusterLabels("test"),
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: "lllamnyp.su/v1alpha2", Kind: "EtcdCluster",
+				APIVersion: "etcd-operator.cozystack.io/v1alpha2", Kind: "EtcdCluster",
 				Name: "test", UID: types.UID("cluster-uid"), Controller: &tru,
 			}},
 		},
@@ -583,7 +583,7 @@ func TestBootstrap_Idempotent(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: seedName, Namespace: "ns", Labels: clusterLabels("test"),
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: "lllamnyp.su/v1alpha2",
+				APIVersion: "etcd-operator.cozystack.io/v1alpha2",
 				Kind:       "EtcdCluster",
 				Name:       "test",
 				UID:        types.UID(clusterUID),
@@ -633,7 +633,7 @@ func TestBootstrap_CompletesPendingSeed(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: seedName, Namespace: "ns", Labels: clusterLabels("test"),
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: "lllamnyp.su/v1alpha2",
+				APIVersion: "etcd-operator.cozystack.io/v1alpha2",
 				Kind:       "EtcdCluster",
 				Name:       "test",
 				UID:        types.UID(clusterUID),
@@ -689,7 +689,7 @@ func TestBootstrap_RejectsStaleSeed(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-stalez", Namespace: "ns", Labels: clusterLabels("test"),
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: "lllamnyp.su/v1alpha2",
+				APIVersion: "etcd-operator.cozystack.io/v1alpha2",
 				Kind:       "EtcdCluster",
 				Name:       "test",
 				UID:        types.UID("stale-uid"), // different from fresh
@@ -1843,7 +1843,7 @@ func TestScaleUp_InitialClusterMatchesEtcdMembership(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-pndng", Namespace: "ns", Labels: clusterLabels("test"),
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: "lllamnyp.su/v1alpha2", Kind: "EtcdCluster",
+				APIVersion: "etcd-operator.cozystack.io/v1alpha2", Kind: "EtcdCluster",
 				Name: "test", UID: types.UID("cluster-uid"), Controller: &tru,
 			}},
 		},
@@ -1942,7 +1942,7 @@ func TestScaleUp_RecoversFromCrashBetweenAddAndPatch(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-pndng", Namespace: "ns", Labels: clusterLabels("test"),
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: "lllamnyp.su/v1alpha2", Kind: "EtcdCluster",
+				APIVersion: "etcd-operator.cozystack.io/v1alpha2", Kind: "EtcdCluster",
 				Name: "test", UID: types.UID("cluster-uid"), Controller: &tru,
 			}},
 		},
@@ -2188,7 +2188,7 @@ func TestClusterUpdateStatus_NoChurnInSteadyState(t *testing.T) {
 			ClusterToken: "ns-test-x",
 			ClusterID:    "0000000000000abc",
 			ReadyMembers: 3,
-			Selector:     "etcd.lllamnyp.su/cluster=test",
+			Selector:     "etcd-operator.cozystack.io/cluster=test",
 			Observed: &lll.ObservedClusterSpec{
 				Replicas: 3, Version: "3.5.17", Storage: lll.StorageSpec{Size: quickQty(t, "1Gi")},
 			},
@@ -2637,7 +2637,7 @@ func TestUpdateStatus_SetsScaleSelector(t *testing.T) {
 	}
 
 	got := mustGet(t, c, "smk", "ns", &lll.EtcdCluster{})
-	want := "etcd.lllamnyp.su/cluster=smk"
+	want := "etcd-operator.cozystack.io/cluster=smk"
 	if got.Status.Selector != want {
 		t.Fatalf("Status.Selector = %q; want %q", got.Status.Selector, want)
 	}

--- a/controllers/etcdmember_controller.go
+++ b/controllers/etcdmember_controller.go
@@ -36,7 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	lll "github.com/lllamnyp/etcd-operator/api/v1alpha2"
+	lll "github.com/cozystack/etcd-operator/api/v1alpha2"
 )
 
 // EtcdMemberReconciler reconciles an EtcdMember object.
@@ -47,10 +47,10 @@ type EtcdMemberReconciler struct {
 	EtcdClientFactory EtcdClientFactory
 }
 
-//+kubebuilder:rbac:groups=lllamnyp.su,resources=etcdmembers,verbs=get;list;watch;update;patch
-//+kubebuilder:rbac:groups=lllamnyp.su,resources=etcdmembers/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=lllamnyp.su,resources=etcdmembers/finalizers,verbs=update
-//+kubebuilder:rbac:groups=lllamnyp.su,resources=etcdclusters,verbs=get
+//+kubebuilder:rbac:groups=etcd-operator.cozystack.io,resources=etcdmembers,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=etcd-operator.cozystack.io,resources=etcdmembers/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=etcd-operator.cozystack.io,resources=etcdmembers/finalizers,verbs=update
+//+kubebuilder:rbac:groups=etcd-operator.cozystack.io,resources=etcdclusters,verbs=get
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;patch;delete
 //+kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
@@ -581,7 +581,7 @@ func (r *EtcdMemberReconciler) buildPod(member *lll.EtcdMember) *corev1.Pod {
 	// writes still count against node-level memory rather than the
 	// pod's cgroup — production memory clusters should also set
 	// resources.limits.memory (tracked in
-	// https://github.com/lllamnyp/etcd-operator/issues/16).
+	// https://github.com/cozystack/etcd-operator/issues/16).
 	var dataVolumeSource corev1.VolumeSource
 	if member.Spec.Storage.Medium == lll.StorageMediumMemory {
 		size := member.Spec.Storage.Size

--- a/controllers/etcdmember_controller_test.go
+++ b/controllers/etcdmember_controller_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	lll "github.com/lllamnyp/etcd-operator/api/v1alpha2"
+	lll "github.com/cozystack/etcd-operator/api/v1alpha2"
 )
 
 // TestRemoveMemberFromEtcd_FallbackByName covers reviewer issue #1: when a
@@ -219,7 +219,7 @@ func TestEnsurePVC_RefusesStaleOwner(t *testing.T) {
 			Name:      "data-test-1",
 			Namespace: "ns",
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: "lllamnyp.su/v1alpha2",
+				APIVersion: "etcd-operator.cozystack.io/v1alpha2",
 				Kind:       "EtcdMember",
 				Name:       "test-1",
 				UID:        staleUID,
@@ -327,7 +327,7 @@ func TestEnsurePVC_AcceptsOwnPVC(t *testing.T) {
 			Name:      "data-test-0",
 			Namespace: "ns",
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: "lllamnyp.su/v1alpha2",
+				APIVersion: "etcd-operator.cozystack.io/v1alpha2",
 				Kind:       "EtcdMember",
 				Name:       "test-0",
 				UID:        uid,
@@ -436,7 +436,7 @@ func TestEnsurePod_RefusesStaleOwner(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-1", Namespace: "ns",
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: "lllamnyp.su/v1alpha2",
+				APIVersion: "etcd-operator.cozystack.io/v1alpha2",
 				Kind:       "EtcdMember",
 				Name:       "test-1",
 				UID:        types.UID("old-uid"),
@@ -517,7 +517,7 @@ func TestEnsurePod_AcceptsOwnPod(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-0", Namespace: "ns", UID: types.UID("pod-uid"),
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: "lllamnyp.su/v1alpha2",
+				APIVersion: "etcd-operator.cozystack.io/v1alpha2",
 				Kind:       "EtcdMember",
 				Name:       "test-0",
 				UID:        uid,
@@ -1113,7 +1113,7 @@ func TestUpdateStatus_NoChurnInSteadyState(t *testing.T) {
 			PVCName:  "data-test-0",
 			MemberID: "0000000000000001",
 			Replicas: 1,
-			Selector: "etcd.lllamnyp.su/cluster=test,app.kubernetes.io/component=test-0",
+			Selector: "etcd-operator.cozystack.io/cluster=test,app.kubernetes.io/component=test-0",
 			Conditions: []metav1.Condition{{
 				Type: lll.MemberReady, Status: metav1.ConditionTrue, Reason: "PodReady",
 				Message: "etcd member is ready", LastTransitionTime: now,
@@ -1283,7 +1283,7 @@ func TestReconcile_DormantMemberDeletesPod(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-saved1", Namespace: "ns",
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: "lllamnyp.su/v1alpha2", Kind: "EtcdMember",
+				APIVersion: "etcd-operator.cozystack.io/v1alpha2", Kind: "EtcdMember",
 				Name: "test-saved1", UID: types.UID("member-uid"), Controller: &tru, BlockOwnerDeletion: &tru,
 			}},
 		},
@@ -1292,7 +1292,7 @@ func TestReconcile_DormantMemberDeletesPod(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "data-test-saved1", Namespace: "ns",
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: "lllamnyp.su/v1alpha2", Kind: "EtcdMember",
+				APIVersion: "etcd-operator.cozystack.io/v1alpha2", Kind: "EtcdMember",
 				Name: "test-saved1", UID: types.UID("member-uid"), Controller: &tru, BlockOwnerDeletion: &tru,
 			}},
 		},
@@ -1362,7 +1362,7 @@ func TestReconcile_WakeFromDormantCreatesPod(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "data-test-saved1", Namespace: "ns",
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: "lllamnyp.su/v1alpha2", Kind: "EtcdMember",
+				APIVersion: "etcd-operator.cozystack.io/v1alpha2", Kind: "EtcdMember",
 				Name: "test-saved1", UID: types.UID("member-uid"), Controller: &tru, BlockOwnerDeletion: &tru,
 			}},
 		},
@@ -1517,7 +1517,7 @@ func TestEnsurePod_CapturesUIDOfExistingPod(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "m-1", Namespace: "ns", UID: types.UID("known-uid"),
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: "lllamnyp.su/v1alpha2", Kind: "EtcdMember",
+				APIVersion: "etcd-operator.cozystack.io/v1alpha2", Kind: "EtcdMember",
 				Name: "m-1", UID: types.UID("mu"), Controller: &tru, BlockOwnerDeletion: &tru,
 			}},
 		},
@@ -1632,7 +1632,7 @@ func TestReconcile_MemoryMemberStablePodIsNotLost(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "m-1", Namespace: "ns", UID: types.UID("stable-uid"),
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: "lllamnyp.su/v1alpha2", Kind: "EtcdMember",
+				APIVersion: "etcd-operator.cozystack.io/v1alpha2", Kind: "EtcdMember",
 				Name: "m-1", UID: types.UID("mu"), Controller: &tru, BlockOwnerDeletion: &tru,
 			}},
 		},
@@ -1679,7 +1679,7 @@ func TestUpdateStatus_MemoryMemberLeavesPVCNameEmpty(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "m-1", Namespace: "ns", UID: types.UID("pod-uid"),
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: "lllamnyp.su/v1alpha2", Kind: "EtcdMember",
+				APIVersion: "etcd-operator.cozystack.io/v1alpha2", Kind: "EtcdMember",
 				Name: "m-1", UID: types.UID("mu"), Controller: &tru, BlockOwnerDeletion: &tru,
 			}},
 		},
@@ -1784,7 +1784,7 @@ func TestEnsurePod_AppliesRoleLabelWhenIsVoter(t *testing.T) {
 			Name: "m-1", Namespace: "ns", UID: types.UID("pod-uid"),
 			Labels: memberLabels("test", "m-1"),
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: "lllamnyp.su/v1alpha2", Kind: "EtcdMember",
+				APIVersion: "etcd-operator.cozystack.io/v1alpha2", Kind: "EtcdMember",
 				Name: "m-1", UID: types.UID("mu"), Controller: &tru, BlockOwnerDeletion: &tru,
 			}},
 		},
@@ -1826,7 +1826,7 @@ func TestEnsurePod_StripsRoleLabelWhenNotVoter(t *testing.T) {
 				LabelRole:    RoleVoter, // stale label from a prior voter state
 			},
 			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: "lllamnyp.su/v1alpha2", Kind: "EtcdMember",
+				APIVersion: "etcd-operator.cozystack.io/v1alpha2", Kind: "EtcdMember",
 				Name: "m-1", UID: types.UID("mu"), Controller: &tru, BlockOwnerDeletion: &tru,
 			}},
 		},

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -7,18 +7,18 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	lll "github.com/lllamnyp/etcd-operator/api/v1alpha2"
+	lll "github.com/cozystack/etcd-operator/api/v1alpha2"
 )
 
 const (
 	// LabelCluster is the label key used to associate resources with an EtcdCluster.
-	LabelCluster = "etcd.lllamnyp.su/cluster"
+	LabelCluster = "etcd-operator.cozystack.io/cluster"
 
 	// LabelRole identifies the etcd-side raft role of a member's Pod. The
 	// only value the operator emits today is RoleVoter; learners carry no
 	// LabelRole at all so the per-cluster PodDisruptionBudget can select
 	// voters exclusively (its selector requires LabelRole=RoleVoter).
-	LabelRole = "etcd.lllamnyp.su/role"
+	LabelRole = "etcd-operator.cozystack.io/role"
 	RoleVoter = "voter"
 
 	// EtcdImage is the container image repository for etcd.
@@ -26,7 +26,7 @@ const (
 
 	// MemberFinalizer is placed on EtcdMember resources to ensure
 	// graceful removal from the etcd cluster before deletion.
-	MemberFinalizer = "etcd.lllamnyp.su/member-cleanup"
+	MemberFinalizer = "etcd-operator.cozystack.io/member-cleanup"
 )
 
 // peerURL returns the etcd peer URL for a member, using the headless Service DNS.

--- a/controllers/testing_helpers_test.go
+++ b/controllers/testing_helpers_test.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	lll "github.com/lllamnyp/etcd-operator/api/v1alpha2"
+	lll "github.com/cozystack/etcd-operator/api/v1alpha2"
 )
 
 // fakeEtcd is a deterministic in-memory stand-in for clientv3.Client used to

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -272,12 +272,12 @@ Every `EtcdCluster` gets a per-cluster `PodDisruptionBudget` (`policy/v1`) named
 
 ### Selector and budget
 
-- **Selector**: `etcd.lllamnyp.su/cluster=<name>, etcd.lllamnyp.su/role=voter`. Only voting members are protected; learners can be evicted freely (a learner-only loss does not affect quorum, and the operator's existing scale-up flow will re-add a learner if the cluster was mid-promotion).
+- **Selector**: `etcd-operator.cozystack.io/cluster=<name>, etcd-operator.cozystack.io/role=voter`. Only voting members are protected; learners can be evicted freely (a learner-only loss does not affect quorum, and the operator's existing scale-up flow will re-add a learner if the cluster was mid-promotion).
 - **MaxUnavailable**: `(votingMembers - 1) / 2`, integer-divided so the result floors automatically. For 1 voter → 0 (any disruption is quorum loss). For 3 → 1, 4 → 1, 5 → 2, 7 → 3.
 
 ### Where the `role=voter` label comes from
 
-The cluster controller is the source of truth for whether a member is a voter; it learns this from etcd's `MemberList` (specifically `IsLearner=false`). It writes `Status.IsVoter` onto each `EtcdMember`. The member controller reads `Status.IsVoter` and patches its Pod's `etcd.lllamnyp.su/role=voter` label accordingly. The new label is visible to the PDB by the next cluster-controller reconcile after promotion — three reconcile cycles end-to-end (cluster writes `IsVoter` → member patches Pod label → cluster's next pass picks up the new voter Pod via `reconcilePDB`). The controller boundaries stay clean: the cluster controller never patches a Pod directly.
+The cluster controller is the source of truth for whether a member is a voter; it learns this from etcd's `MemberList` (specifically `IsLearner=false`). It writes `Status.IsVoter` onto each `EtcdMember`. The member controller reads `Status.IsVoter` and patches its Pod's `etcd-operator.cozystack.io/role=voter` label accordingly. The new label is visible to the PDB by the next cluster-controller reconcile after promotion — three reconcile cycles end-to-end (cluster writes `IsVoter` → member patches Pod label → cluster's next pass picks up the new voter Pod via `reconcilePDB`). The controller boundaries stay clean: the cluster controller never patches a Pod directly.
 
 The seed is **pre-stamped** with `Status.IsVoter=true` at creation — it's never a learner, so the operator skips the round-trip and the Pod gets the role label on the very first reconcile, closing the bootstrap-window protection gap.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -68,7 +68,7 @@ The `bin/kustomize-v*` binary is auto-downloaded by `make kustomize` (version pi
 
 ```sh
 cat <<'EOF' | kubectl apply -f -
-apiVersion: lllamnyp.su/v1alpha2
+apiVersion: etcd-operator.cozystack.io/v1alpha2
 kind: EtcdCluster
 metadata:
   name: my-etcd
@@ -84,7 +84,7 @@ EOF
 Watch it form:
 
 ```sh
-kubectl get etcdcluster.lllamnyp.su my-etcd -w
+kubectl get etcdcluster.etcd-operator.cozystack.io my-etcd -w
 ```
 
 The operator bootstraps a single seed first, latches `clusterID`, then adds the remaining members one at a time as learners (with promotion). A 3-member cluster typically reaches `READY=3` in well under a minute on a healthy cluster.
@@ -92,7 +92,7 @@ The operator bootstraps a single seed first, latches `clusterID`, then adds the 
 To open a shell to one of the members:
 
 ```sh
-POD=$(kubectl get pod -l etcd.lllamnyp.su/cluster=my-etcd \
+POD=$(kubectl get pod -l etcd-operator.cozystack.io/cluster=my-etcd \
   -o jsonpath='{.items[0].metadata.name}')
 kubectl exec -it "$POD" -- etcdctl --endpoints=http://localhost:2379 \
   member list -w table
@@ -105,7 +105,7 @@ Don't hard-code Pod names — they carry a random suffix from `GenerateName` (e.
 For reconstructable workloads (e.g. a Kubernetes-in-Kubernetes apiserver whose state is GitOps-managed) you can opt the cluster onto a tmpfs `emptyDir` instead of a PVC:
 
 ```yaml
-apiVersion: lllamnyp.su/v1alpha2
+apiVersion: etcd-operator.cozystack.io/v1alpha2
 kind: EtcdCluster
 metadata:
   name: my-mem-etcd
@@ -180,7 +180,7 @@ Single-namespace scoping is not currently exposed: `main.go` does not wire a nam
 
 The operator creates two Services per `EtcdCluster`:
 
-- **`<cluster>`** — headless (`clusterIP: None`), `publishNotReadyAddresses: true`, selector `etcd.lllamnyp.su/cluster=<cluster>`, exposes **both 2379 (client) and 2380 (peer)**. Used by etcd for peer discovery and by the operator's own etcd client (which dials per-pod DNS `<member>.<cluster>.<ns>.svc:2379` resolved through this service). `publishNotReadyAddresses` is required for bootstrap: members during the initial join window aren't `Ready` yet but still need DNS entries to find each other.
+- **`<cluster>`** — headless (`clusterIP: None`), `publishNotReadyAddresses: true`, selector `etcd-operator.cozystack.io/cluster=<cluster>`, exposes **both 2379 (client) and 2380 (peer)**. Used by etcd for peer discovery and by the operator's own etcd client (which dials per-pod DNS `<member>.<cluster>.<ns>.svc:2379` resolved through this service). `publishNotReadyAddresses` is required for bootstrap: members during the initial join window aren't `Ready` yet but still need DNS entries to find each other.
 - **`<cluster>-client`** — `ClusterIP`, exposes 2379 only. Intended for end-user client traffic (load-balanced across all pods backing the selector).
 
 External access (NodePort / LoadBalancer / Ingress) isn't created automatically. If you need it, layer a separate Service or Ingress on top of `<cluster>-client`'s selector.
@@ -197,7 +197,7 @@ This is outside the operator's scope but documented because operators ask.
 
 ```sh
 # Remove individual clusters first — their finalizers will clean up etcd state.
-kubectl delete etcdcluster.lllamnyp.su --all -A
+kubectl delete etcdcluster.etcd-operator.cozystack.io --all -A
 
 # Remove the operator.
 make undeploy

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -8,25 +8,25 @@ The two queries you'll use most:
 
 ```sh
 # Cluster-level view: replicas, ready count, cluster ID, conditions.
-kubectl get etcdcluster.lllamnyp.su -A
-kubectl get etcdcluster.lllamnyp.su <name> -n <ns> -o yaml
+kubectl get etcdcluster.etcd-operator.cozystack.io -A
+kubectl get etcdcluster.etcd-operator.cozystack.io <name> -n <ns> -o yaml
 
 # Member-level view: per-member bootstrap flag, dormancy, ready state.
-kubectl get etcdmember.lllamnyp.su -n <ns> -o custom-columns=\
+kubectl get etcdmember.etcd-operator.cozystack.io -n <ns> -o custom-columns=\
 'NAME:.metadata.name,BOOTSTRAP:.spec.bootstrap,DORMANT:.spec.dormant,READY:.status.conditions[?(@.type=="Ready")].status,MEMBERID:.status.memberID'
 ```
 
 Member names are apiserver-assigned random suffixes (`<cluster>-<5-char>`); don't hard-code them in scripts. Always use the cluster label:
 
 ```sh
-kubectl get pod -l etcd.lllamnyp.su/cluster=<cluster> -n <ns>
-kubectl get pvc -l etcd.lllamnyp.su/cluster=<cluster> -n <ns>
+kubectl get pod -l etcd-operator.cozystack.io/cluster=<cluster> -n <ns>
+kubectl get pvc -l etcd-operator.cozystack.io/cluster=<cluster> -n <ns>
 ```
 
 To talk to etcd directly, pick any Pod via the label and exec:
 
 ```sh
-POD=$(kubectl get pod -l etcd.lllamnyp.su/cluster=<cluster> -n <ns> \
+POD=$(kubectl get pod -l etcd-operator.cozystack.io/cluster=<cluster> -n <ns> \
   -o jsonpath='{.items[0].metadata.name}')
 kubectl exec -n <ns> "$POD" -- etcdctl --endpoints=http://localhost:2379 \
   endpoint health --cluster
@@ -39,21 +39,21 @@ The operator commits to a target on the first reconcile that sees the new spec �
 ### Scale up
 
 ```sh
-kubectl patch etcdcluster.lllamnyp.su <name> -n <ns> --type=merge \
+kubectl patch etcdcluster.etcd-operator.cozystack.io <name> -n <ns> --type=merge \
   -p '{"spec":{"replicas":5}}'
 ```
 
 The operator adds one member at a time as a learner, waits for it to report `Ready=True`, then promotes it before adding the next. Each step is gated on the previous learner reaching `Ready`. On a fresh cluster with no data each step completes in well under a second on etcd's side and the operator's reconcile cadence (~30 s requeue) dominates wall time; on clusters with non-trivial data volumes the learner-sync time can become the dominant factor (etcd has to ship the data dir before `MemberPromote` is accepted). Watch progress with:
 
 ```sh
-kubectl get etcdcluster.lllamnyp.su <name> -n <ns> \
+kubectl get etcdcluster.etcd-operator.cozystack.io <name> -n <ns> \
   -o jsonpath='{.status.readyMembers}/{.status.observed.replicas}{"\n"}'
 ```
 
 ### Scale down
 
 ```sh
-kubectl patch etcdcluster.lllamnyp.su <name> -n <ns> --type=merge \
+kubectl patch etcdcluster.etcd-operator.cozystack.io <name> -n <ns> --type=merge \
   -p '{"spec":{"replicas":3}}'
 ```
 
@@ -62,7 +62,7 @@ Picks the most-recently-created member as the victim (`CreationTimestamp` DESC, 
 ### Pause (scale to 0)
 
 ```sh
-kubectl patch etcdcluster.lllamnyp.su <name> -n <ns> --type=merge \
+kubectl patch etcdcluster.etcd-operator.cozystack.io <name> -n <ns> --type=merge \
   -p '{"spec":{"replicas":0}}'
 ```
 
@@ -72,31 +72,31 @@ Observable state once paused:
 
 ```sh
 # One EtcdMember CR with spec.dormant=true:
-kubectl get etcdmember.lllamnyp.su -n <ns> \
+kubectl get etcdmember.etcd-operator.cozystack.io -n <ns> \
   -o custom-columns=NAME:.metadata.name,DORMANT:.spec.dormant
 
 # One PVC remaining (data-<member-name>):
-kubectl get pvc -l etcd.lllamnyp.su/cluster=<cluster> -n <ns>
+kubectl get pvc -l etcd-operator.cozystack.io/cluster=<cluster> -n <ns>
 
 # No Pods:
-kubectl get pod -l etcd.lllamnyp.su/cluster=<cluster> -n <ns>
+kubectl get pod -l etcd-operator.cozystack.io/cluster=<cluster> -n <ns>
 
 # Available=False, Reason=Paused, message names the PVC:
-kubectl get etcdcluster.lllamnyp.su <name> -n <ns> \
+kubectl get etcdcluster.etcd-operator.cozystack.io <name> -n <ns> \
   -o jsonpath='{.status.conditions[?(@.type=="Available")]}{"\n"}'
 ```
 
 ### Resume (scale to 1+)
 
 ```sh
-kubectl patch etcdcluster.lllamnyp.su <name> -n <ns> --type=merge \
+kubectl patch etcdcluster.etcd-operator.cozystack.io <name> -n <ns> --type=merge \
   -p '{"spec":{"replicas":3}}'
 ```
 
 The cluster controller spots the dormant member, patches `spec.dormant=false`, and the member controller's next pass recreates the Pod against the existing PVC. Etcd reads the data dir and resumes with the **same cluster ID and member ID** as before the pause — verify with:
 
 ```sh
-kubectl get etcdcluster.lllamnyp.su <name> -n <ns> -o jsonpath='{.status.clusterID}'
+kubectl get etcdcluster.etcd-operator.cozystack.io <name> -n <ns> -o jsonpath='{.status.clusterID}'
 # Should match the value you saw before the pause.
 ```
 
@@ -118,9 +118,9 @@ Expected when `spec.replicas=0`. Inspect the message for whether data is preserv
 Less than half of `observed.replicas` are ready. The cluster cannot serve writes. Check:
 
 ```sh
-kubectl get etcdmember.lllamnyp.su -n <ns> \
+kubectl get etcdmember.etcd-operator.cozystack.io -n <ns> \
   -o custom-columns=NAME:.metadata.name,READY:.status.conditions[?(@.type=="Ready")].status
-kubectl get pod -l etcd.lllamnyp.su/cluster=<cluster> -n <ns> -o wide
+kubectl get pod -l etcd-operator.cozystack.io/cluster=<cluster> -n <ns> -o wide
 kubectl describe pod -n <ns> <unhealthy-pod>
 ```
 
@@ -133,9 +133,9 @@ If quorum is recoverable (Pods come back), the cluster heals on its own. If a me
 Bootstrap discovery couldn't dial the seed. The message comes via `stableErrorMessage(err)` which strips per-call variable portions (timestamps, port numbers), so the same root cause reads consistently across retries.
 
 ```sh
-kubectl get etcdcluster.lllamnyp.su <name> -n <ns> \
+kubectl get etcdcluster.etcd-operator.cozystack.io <name> -n <ns> \
   -o jsonpath='{.status.conditions[?(@.type=="Available")].message}{"\n"}'
-kubectl get pod -l etcd.lllamnyp.su/cluster=<cluster> -n <ns>
+kubectl get pod -l etcd-operator.cozystack.io/cluster=<cluster> -n <ns>
 kubectl logs -n <ns> <seed-pod>
 ```
 
@@ -154,9 +154,9 @@ kubectl run dns-debug --rm -it --image=busybox -n <ns> -- \
 Terminal. The deadline expired before `clusterID` was latched. The partial seed's Pod carries an `--initial-cluster` flag baked in; the operator cannot change it in-place. Recovery is:
 
 ```sh
-kubectl delete etcdcluster.lllamnyp.su <name> -n <ns>
+kubectl delete etcdcluster.etcd-operator.cozystack.io <name> -n <ns>
 # Wait for all dependents to be GC'd:
-kubectl get etcdmember,pvc -l etcd.lllamnyp.su/cluster=<cluster> -n <ns>
+kubectl get etcdmember,pvc -l etcd-operator.cozystack.io/cluster=<cluster> -n <ns>
 # Once that returns no resources, re-create.
 kubectl apply -f <your-cluster-manifest>.yaml
 ```
@@ -169,12 +169,12 @@ Terminal. The deadline expired after bootstrap (the cluster itself is healthy; o
 
 ```sh
 # Inspect what's stuck:
-kubectl get etcdcluster.lllamnyp.su <name> -n <ns> -o yaml
+kubectl get etcdcluster.etcd-operator.cozystack.io <name> -n <ns> -o yaml
 # observed shows what the operator was trying to reach;
 # spec shows what you originally asked for.
 
 # Edit spec to something sane (often: revert to the previous working value):
-kubectl edit etcdcluster.lllamnyp.su <name> -n <ns>
+kubectl edit etcdcluster.etcd-operator.cozystack.io <name> -n <ns>
 ```
 
 The next reconcile notices `spec != observed`, treats your edit as the intervention signal, snapshots the new spec into `observed`, sets a fresh deadline, and resumes.
@@ -184,22 +184,22 @@ The next reconcile notices `spec != observed`, treats your edit as the intervent
 The seed `EtcdMember` CR exists but the member controller hasn't yet created its Pod — this is the gap between the cluster controller creating the CR and the member controller's next reconcile pass. `kubectl describe pod` is **not** useful here: there is no Pod yet, so it returns "not found" and obscures the actual state. Inspect the CR and the namespace's events instead:
 
 ```sh
-SEED=$(kubectl get etcdmember.lllamnyp.su -n <ns> \
+SEED=$(kubectl get etcdmember.etcd-operator.cozystack.io -n <ns> \
   -o jsonpath='{.items[?(@.spec.bootstrap==true)].metadata.name}')
-kubectl describe etcdmember.lllamnyp.su -n <ns> "$SEED"
+kubectl describe etcdmember.etcd-operator.cozystack.io -n <ns> "$SEED"
 kubectl get events -n <ns> --field-selector involvedObject.name=$SEED
 ```
 
 In normal operation this state clears within one or two reconcile cycles. If it persists, the operator controller is wedged — check its logs (see [Operator logs](#operator-logs)).
 
-Once the seed Pod is created, `WaitingForSeed` clears and any *Pod*-side problems (`StorageClass` missing, image-pull failure, `PodSecurity` admission rejection of the `restricted`-compatible spec) surface separately. At that point `kubectl describe pod -l etcd.lllamnyp.su/cluster=<cluster> -n <ns>` is the right tool.
+Once the seed Pod is created, `WaitingForSeed` clears and any *Pod*-side problems (`StorageClass` missing, image-pull failure, `PodSecurity` admission rejection of the `restricted`-compatible spec) surface separately. At that point `kubectl describe pod -l etcd-operator.cozystack.io/cluster=<cluster> -n <ns>` is the right tool.
 
 ## Forcing escalation: shortening the deadline
 
 The default `progressDeadlineSeconds` is 600 (10 minutes). If a reconcile is wedged and you don't want to wait out the window, force the deadline now:
 
 ```sh
-kubectl patch etcdcluster.lllamnyp.su <name> -n <ns> --subresource=status --type=merge \
+kubectl patch etcdcluster.etcd-operator.cozystack.io <name> -n <ns> --subresource=status --type=merge \
   -p "{\"status\":{\"progressDeadline\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ -d '1 second ago')\"}}"
 ```
 
@@ -213,10 +213,10 @@ Manual recovery:
 
 ```sh
 # 1. Identify the broken member.
-kubectl get etcdmember.lllamnyp.su -n <ns>
+kubectl get etcdmember.etcd-operator.cozystack.io -n <ns>
 # 2. Delete it — the finalizer runs MemberRemove against peers, then GC takes
 #    the Pod and PVC. Quorum holds because we remove before adding.
-kubectl delete etcdmember.lllamnyp.su <broken-member> -n <ns>
+kubectl delete etcdmember.etcd-operator.cozystack.io <broken-member> -n <ns>
 # 3. The cluster controller's next reconcile observes current < desired and
 #    scales up automatically — a new member is added with GenerateName and
 #    fresh storage.
@@ -229,7 +229,7 @@ This sequence preserves quorum if you have an odd number of voters and only one 
 The operator only surfaces what it needs for its own decisions. For deeper inspection talk to etcd:
 
 ```sh
-POD=$(kubectl get pod -l etcd.lllamnyp.su/cluster=<cluster> -n <ns> \
+POD=$(kubectl get pod -l etcd-operator.cozystack.io/cluster=<cluster> -n <ns> \
   -o jsonpath='{.items[0].metadata.name}')
 
 # Cluster ID, leader, members:
@@ -281,7 +281,7 @@ Opt-in via `spec.storage.medium: Memory`. Each member's data dir is a tmpfs `emp
 
 ```sh
 cat <<'EOF' | kubectl apply -f -
-apiVersion: lllamnyp.su/v1alpha2
+apiVersion: etcd-operator.cozystack.io/v1alpha2
 kind: EtcdCluster
 metadata:
   name: my-mem-etcd
@@ -302,7 +302,7 @@ EOF
 The Pod's volume tells you:
 
 ```sh
-kubectl get pod -l etcd.lllamnyp.su/cluster=my-mem-etcd -n default \
+kubectl get pod -l etcd-operator.cozystack.io/cluster=my-mem-etcd -n default \
   -o jsonpath='{.items[0].spec.volumes[?(@.name=="data")]}' | jq
 # Expect: {"emptyDir": {"medium": "Memory", "sizeLimit": "256Mi"}, ...}
 ```
@@ -310,7 +310,7 @@ kubectl get pod -l etcd.lllamnyp.su/cluster=my-mem-etcd -n default \
 And inside the Pod:
 
 ```sh
-POD=$(kubectl get pod -l etcd.lllamnyp.su/cluster=my-mem-etcd -n default \
+POD=$(kubectl get pod -l etcd-operator.cozystack.io/cluster=my-mem-etcd -n default \
   -o jsonpath='{.items[0].metadata.name}')
 kubectl exec -n default "$POD" -- mount | grep /var/lib/etcd
 # Expect: tmpfs on /var/lib/etcd type tmpfs (...)
@@ -319,7 +319,7 @@ kubectl exec -n default "$POD" -- mount | grep /var/lib/etcd
 No PVCs should exist for the cluster:
 
 ```sh
-kubectl get pvc -l etcd.lllamnyp.su/cluster=my-mem-etcd -n default
+kubectl get pvc -l etcd-operator.cozystack.io/cluster=my-mem-etcd -n default
 # No resources found.
 ```
 
@@ -336,7 +336,7 @@ The `PodDisruptionBudget` is auto-emitted now (see [Draining nodes](#draining-no
          requiredDuringSchedulingIgnoredDuringExecution:
            - labelSelector:
                matchLabels:
-                 etcd.lllamnyp.su/cluster: my-mem-etcd
+                 etcd-operator.cozystack.io/cluster: my-mem-etcd
              topologyKey: kubernetes.io/hostname
    ```
 
@@ -368,7 +368,7 @@ The operator detects Pod loss via `Status.PodUID`. The two scenarios:
 Watch the auto-replacement happen:
 
 ```sh
-kubectl get etcdmember.lllamnyp.su -n default -w
+kubectl get etcdmember.etcd-operator.cozystack.io -n default -w
 # Original: my-mem-etcd-abc12, my-mem-etcd-def34, my-mem-etcd-ghi56.
 # Force-delete one Pod: kubectl delete pod -n default my-mem-etcd-abc12
 # Observe the EtcdMember CR get deleted, a new one with a fresh GenerateName
@@ -380,7 +380,7 @@ kubectl get etcdmember.lllamnyp.su -n default -w
 Setting `spec.replicas: 0` on a memory cluster is **rejected by the apiserver** (CEL validation rule on `EtcdClusterSpec`):
 
 ```
-kubectl patch etcdcluster.lllamnyp.su my-mem-etcd -n default --type=merge \
+kubectl patch etcdcluster.etcd-operator.cozystack.io my-mem-etcd -n default --type=merge \
   -p '{"spec":{"replicas":0}}'
 # The EtcdCluster "my-mem-etcd" is invalid: spec: Invalid value: ...:
 #   spec.replicas=0 with spec.storage.medium=Memory is unsupported: ...
@@ -409,13 +409,13 @@ That's the intended behaviour — your drain just refused to break quorum. Resol
 
 ### Which Pods are voters
 
-Voter Pods carry the label `etcd.lllamnyp.su/role=voter`. Learners do not. To find them:
+Voter Pods carry the label `etcd-operator.cozystack.io/role=voter`. Learners do not. To find them:
 
 ```sh
-kubectl get pod -l etcd.lllamnyp.su/cluster=<cluster>,etcd.lllamnyp.su/role=voter -n <ns>
+kubectl get pod -l etcd-operator.cozystack.io/cluster=<cluster>,etcd-operator.cozystack.io/role=voter -n <ns>
 ```
 
-Cross-reference against `kubectl get etcdmember.lllamnyp.su -n <ns>` — voters there have `Status.IsVoter: true` (written by the cluster controller from etcd's `MemberList`).
+Cross-reference against `kubectl get etcdmember.etcd-operator.cozystack.io -n <ns>` — voters there have `Status.IsVoter: true` (written by the cluster controller from etcd's `MemberList`).
 
 ### Why drains might block during scale events
 
@@ -428,14 +428,14 @@ If you're doing a planned rolling node maintenance, scale down to the resilient 
 ### Find the dormant member
 
 ```sh
-kubectl get etcdmember.lllamnyp.su -n <ns> \
+kubectl get etcdmember.etcd-operator.cozystack.io -n <ns> \
   -o jsonpath='{range .items[?(@.spec.dormant==true)]}{.metadata.name}{"\n"}{end}'
 ```
 
 ### Find the seed of a running cluster
 
 ```sh
-kubectl get etcdmember.lllamnyp.su -n <ns> \
+kubectl get etcdmember.etcd-operator.cozystack.io -n <ns> \
   -o jsonpath='{range .items[?(@.spec.bootstrap==true)]}{.metadata.name}{"\n"}{end}'
 ```
 
@@ -444,7 +444,7 @@ Note: the seed has no special operational role post-bootstrap — see [concepts]
 ### Tail logs from the etcd leader
 
 ```sh
-POD=$(kubectl get pod -l etcd.lllamnyp.su/cluster=<cluster> -n <ns> \
+POD=$(kubectl get pod -l etcd-operator.cozystack.io/cluster=<cluster> -n <ns> \
   -o jsonpath='{.items[0].metadata.name}')
 LEADER=$(kubectl exec -n <ns> "$POD" -- etcdctl \
   --endpoints=http://localhost:2379 endpoint status --cluster -w json \
@@ -511,7 +511,7 @@ kubectl create secret generic my-cluster-peer-tls -n <ns> \
 Then reference them in the cluster spec:
 
 ```yaml
-apiVersion: lllamnyp.su/v1alpha2
+apiVersion: etcd-operator.cozystack.io/v1alpha2
 kind: EtcdCluster
 metadata:
   name: my-cluster
@@ -538,7 +538,7 @@ Server-TLS-only (encryption without client identity) drops the `operatorClientSe
 The hardcoded `--endpoints=http://localhost:2379` examples elsewhere in this doc become:
 
 ```sh
-POD=$(kubectl get pod -l etcd.lllamnyp.su/cluster=<cluster> -n <ns> \
+POD=$(kubectl get pod -l etcd-operator.cozystack.io/cluster=<cluster> -n <ns> \
   -o jsonpath='{.items[0].metadata.name}')
 
 # Stage a client cert+key inside the Pod for an exec-side etcdctl. Any

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/lllamnyp/etcd-operator
+module github.com/cozystack/etcd-operator
 
 go 1.25.0
 

--- a/main.go
+++ b/main.go
@@ -37,8 +37,8 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	lllamnypsuv1alpha2 "github.com/lllamnyp/etcd-operator/api/v1alpha2"
-	"github.com/lllamnyp/etcd-operator/controllers"
+	lllamnypsuv1alpha2 "github.com/cozystack/etcd-operator/api/v1alpha2"
+	"github.com/cozystack/etcd-operator/controllers"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -89,7 +89,7 @@ func main() {
 		WebhookServer:          webhook.NewServer(webhook.Options{Port: 9443}),
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
-		LeaderElectionID:       "aa20b3a9.lllamnyp.su",
+		LeaderElectionID:       "aa20b3a9.etcd-operator.cozystack.io",
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	lllamnypsuv1alpha2 "github.com/cozystack/etcd-operator/api/v1alpha2"
+	etcdv1alpha2 "github.com/cozystack/etcd-operator/api/v1alpha2"
 	"github.com/cozystack/etcd-operator/controllers"
 	//+kubebuilder:scaffold:imports
 )
@@ -52,7 +52,7 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
-	utilruntime.Must(lllamnypsuv1alpha2.AddToScheme(scheme))
+	utilruntime.Must(etcdv1alpha2.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 


### PR DESCRIPTION
## What

Mechanical rename of the freshly imported `v1` base (originally `lllamnyp/etcd-operator`) onto the Cozystack identity. No behavioural changes.

- **API group:** `lllamnyp.su` → `etcd-operator.cozystack.io` (version `v1alpha2` unchanged)
- **Go module:** `github.com/lllamnyp/etcd-operator` → `github.com/cozystack/etcd-operator`
- **Label / finalizer keys:** now prefixed with the API group itself — `etcd-operator.cozystack.io/cluster`, `/role`, `/member-cleanup` — instead of the previous `etcd.lllamnyp.su/…` form. **Decision open to review:** dropped the redundant `etcd.` segment rather than producing `etcd.etcd-operator.cozystack.io/…`.
- CRD manifests, RBAC, samples and deepcopy regenerated (`make manifests generate`).
- Upstream issue/PR cross-links in `docs/` and `README.md` deliberately left pointing at `lllamnyp/etcd-operator` (those issues live there; docs get rewritten in a later phase).

## Out of scope

- Docker image name in `.github/workflows/publish.yml` (still `lllamnyp/etcd-operator`) — CI/publishing rename is a separate change.
- The go module path `github.com/cozystack/etcd-operator` will not resolve via `go get` until `cozystack/etcd-operator` exists; local builds and CI are unaffected.

## Verification

- `go build ./...` ✓
- `go vet ./...` ✓
- `make test` (envtest, k8s 1.33) ✓ — all packages green

Part of the migration tracked in #318. Targets the `v1` integration branch.
