### PR TITLE
fix(ci): make docs-only PRs mergeable (gate required e2e/smoke per-job)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,14 +6,13 @@ on:
   # a branch PRs never target (this said `master`, which does not exist) means
   # the workflow never runs at all.
   #
-  # paths-ignore: a kind+cert-manager+Kamaji provisioning run costs ~30-45
-  # minutes; skip it for PRs that touch nothing the suite exercises
-  # (docs-only changes). Everything else — Go code, manifests, the harness,
-  # the workflows themselves — still gates.
+  # No paths filter on the trigger either: `kamaji-datastore` is a *required*
+  # status check, and a workflow skipped at the trigger never reports its
+  # check, leaving the required context stuck in "Expected" — which blocks the
+  # PR forever (e.g. docs-only PRs). Path filtering instead lives in the
+  # `changes` job below; a job skipped via `if:` still reports its check as
+  # "skipped", which branch protection treats as passing.
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
   push:
     tags: [ "v*" ]
   workflow_dispatch:
@@ -23,7 +22,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    # Cheap (~seconds, no checkout — dorny uses the PR API) gate that decides
+    # whether the expensive job below needs to run. PR-only: tag pushes and
+    # manual dispatch always run the suite unconditionally (see the `if` on
+    # kamaji-datastore).
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # `code` is true when the PR touches anything the e2e suite
+          # exercises. Only-negated patterns get an implicit `**`, so this
+          # reads as "all files except Markdown and docs/**" — i.e. docs-only
+          # PRs leave `code` false and the ~30-45 min run below is skipped.
+          filters: |
+            code:
+              - '!**/*.md'
+              - '!docs/**'
+
   kamaji-datastore:
+    needs: changes
+    # Always run for tag pushes / manual dispatch; for PRs, run only when
+    # non-docs files changed. When skipped on a docs-only PR the check still
+    # reports (as "skipped" = passing), so the PR is not blocked.
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -10,17 +10,13 @@ name: Release install smoke
 # introduces them, not on the first real tag. The image is loaded into kind,
 # never pushed — no registry credentials.
 on:
+  # No paths filter on the trigger: `smoke (helm)` and `smoke (manifest)` are
+  # *required* status checks, and a workflow skipped at the trigger never
+  # reports them, leaving the required contexts stuck in "Expected" and
+  # blocking the PR forever (e.g. docs-only PRs). Path filtering lives in the
+  # `changes` job below instead; the matrix job is skipped via `if:` when
+  # nothing release-relevant changed, and a skipped check counts as passing.
   pull_request:
-    paths:
-      - '.github/workflows/release-smoke.yml'
-      - '.github/workflows/docker-publish.yml'
-      - '.github/workflows/release-assets.yml'
-      - '.github/workflows/helm-publish.yml'
-      - 'hack/release-smoke.sh'
-      - 'charts/**'
-      - 'Makefile'
-      - 'Dockerfile'
-      - 'api/**'
   workflow_dispatch:
 
 concurrency:
@@ -28,7 +24,38 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    # Cheap (~seconds, no checkout) gate. PR-only: manual dispatch always runs
+    # the smoke matrix unconditionally (see the `if` on smoke).
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.filter.outputs.release }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # True when the PR touches the tag-release machinery or anything it
+          # ships. Matches the paths this workflow used to filter on at the
+          # trigger; PRs that touch none of these skip the two kind smokes.
+          filters: |
+            release:
+              - '.github/workflows/release-smoke.yml'
+              - '.github/workflows/docker-publish.yml'
+              - '.github/workflows/release-assets.yml'
+              - '.github/workflows/helm-publish.yml'
+              - 'hack/release-smoke.sh'
+              - 'charts/**'
+              - 'Makefile'
+              - 'Dockerfile'
+              - 'api/**'
+
   smoke:
+    needs: changes
+    # Always run on manual dispatch; for PRs, run only when release-relevant
+    # files changed. When skipped, each matrix leg's required check still
+    # reports as "skipped" (= passing), so the PR is not blocked.
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.release == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
## What

Move the path filtering on the e2e and release-smoke workflows off the `on:` trigger and into a per-job `if:` gate, so that PRs which touch none of the filtered paths (docs-only PRs in particular) become mergeable.

Closes #333.

## Why

Branch protection on `main` requires six contexts: `DCO`, `verify`, `image-multiarch`, `kamaji-datastore`, `smoke (helm)`, `smoke (manifest)`. The last three come from workflows that filtered themselves out at the trigger:

- `kamaji-datastore` (`e2e.yml`) — `pull_request: paths-ignore: ['**.md', 'docs/**']`
- `smoke (helm)` / `smoke (manifest)` (`release-smoke.yml`) — a `pull_request: paths:` allowlist

A workflow skipped **at the trigger** never creates its check context, so branch protection holds the required context in `Expected` forever and the PR stays `BLOCKED`. `enforce_admins` is on, so there is no admin-merge bypass. That is exactly what happened to #331.

## How

The fix relies on the distinction GitHub draws between the two ways a check can be absent:

- skipped **at the trigger** → context never reported → **blocks** (the bug);
- skipped **via a job-level `if:`** → context reported as `skipped` → branch protection treats it as **passing**.

So each workflow now:

1. always triggers on `pull_request` (no path filter);
2. runs a cheap `changes` job (`dorny/paths-filter`, no checkout — it uses the PR API, ~seconds) that detects whether relevant paths changed;
3. guards the expensive job with `if:` on that output, plus `github.event_name != 'pull_request'` so tag pushes / manual dispatch still run unconditionally.

On a docs-only PR the workflows start, the detector runs, and the ~30–45 min `kamaji-datastore` and the two kind smokes are **skipped** (zero compute) — but each required context reports `skipped` → passing. The cost-saving intent of the original filters is preserved; only the deadlock is removed.

The `smoke` matrix (`mode: [manifest, helm]`) is kept as-is so the required context names `smoke (helm)` / `smoke (manifest)` are unchanged — splitting it into two jobs would rename the contexts and require editing branch protection.

## Verification needed before relying on it

Confirm that the `smoke` matrix job, when skipped via the job-level `if:`, still emits the per-leg contexts `smoke (helm)` and `smoke (manifest)` as `skipped` rather than a single collapsed `smoke`. It normally does, but this PR is itself a non-docs change (it edits workflows), so its own run will *exercise* the jobs rather than skip them — the skip path is best confirmed with a throwaway docs-only PR stacked on this branch, or by watching the next real docs-only PR. If the matrix collapses, the fallback is a sentinel job.

## Note on #331

#331 (the docs PR that surfaced this) was unblocked out-of-band by dispatching both workflows against its head ref via `workflow_dispatch`, which produces the three contexts on the head SHA. That is a one-off; this PR removes the need to repeat it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to improve test execution efficiency. Documentation-only pull requests now display test status checks as skipped rather than omitted, while expensive integration tests are skipped when only non-code files are modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->