### PR TITLE
chore(codeowners): declare repository ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Ownership for this sub-project.
+#
+# The Cozystack maintainers are maintainers of every sub-project by default
+# (https://github.com/cozystack/cozystack/blob/main/MAINTAINERS.md). The
+# handles below are the people who own this repository day to day and whose
+# review is requested on every change here.
+
+* @lllamnyp @androndo


### PR DESCRIPTION
Declares who owns this repository, so review routes to them instead of to nobody.

Ownership follows the roster being documented in cozystack/cozystack#3462: the Cozystack maintainers are maintainers of every sub-project by default, and this file names the people who own this one day to day.

Part of aligning code ownership in GitHub with the documented governance roles, which is a required item for the CNCF Incubation review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added repository ownership rules via a new CODEOWNERS file to streamline code review assignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->