### PR TITLE
test(e2e): pick a non-seed victim in the self-heal test

### DIFF
--- a/test/e2e/member_selfheal_test.go
+++ b/test/e2e/member_selfheal_test.go
@@ -74,7 +74,7 @@ func TestPVCMemberCrashLoopSelfHeal(t *testing.T) {
 	if len(original) != 3 {
 		t.Fatalf("expected 3 members, got %d: %v", len(original), original)
 	}
-	victim := original[0]
+	victim := selfHealReplaceableMember(ctx, t)
 	victimPVC := "data-" + victim
 	t.Logf("corrupting data dir of victim member %q (pvc %q)", victim, victimPVC)
 
@@ -99,7 +99,7 @@ func TestPVCMemberCrashLoopSelfHeal(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			return fmt.Errorf("victim %q still present (crash-loop not yet past threshold)", victim)
+			return fmt.Errorf("victim %q still present; %s", victim, etcdRestartState(ctx, victim))
 		})
 
 	// The corrupt member's PVC must be GC'd (owner-ref), discarding the bad
@@ -166,6 +166,66 @@ func selfHealMembers(ctx context.Context, t *testing.T) []string {
 		names = append(names, list.Items[i].Name)
 	}
 	return names
+}
+
+// selfHealReplaceableMember returns a member that is eligible for self-heal —
+// i.e. any member except the bootstrap seed.
+//
+// The seed is permanently excluded from the self-heal path: the caller of
+// etcdContainerStuck gates on !member.Spec.Bootstrap, and Spec.Bootstrap is set
+// once at member creation and never cleared. Corrupting the seed therefore
+// waits out the full 15m timeout for a deletion that is by design never coming.
+//
+// Picking by index (the previous `original[0]`) hit exactly that: List returns
+// items name-sorted and member names are apiserver-assigned random suffixes, so
+// the seed sorted first — and became the victim — in roughly one run in three.
+// The seed-exclusion contract itself is covered by the unit test
+// TestUpdateStatus_KeepsStuckBootstrapMember; this test covers the replaceable
+// case, so it must pick a replaceable member deterministically.
+func selfHealReplaceableMember(ctx context.Context, t *testing.T) string {
+	t.Helper()
+	list := &etcdv1alpha2.EtcdMemberList{}
+	if err := kube.List(ctx, list, client.InNamespace(selfHealNamespace),
+		client.MatchingLabels{"etcd-operator.cozystack.io/cluster": selfHealCluster}); err != nil {
+		t.Fatalf("list members: %v", err)
+	}
+	var seeds, eligible []string
+	for i := range list.Items {
+		if list.Items[i].Spec.Bootstrap {
+			seeds = append(seeds, list.Items[i].Name)
+			continue
+		}
+		eligible = append(eligible, list.Items[i].Name)
+	}
+	// Exactly one seed is an invariant of bootstrap (the cluster controller
+	// finds the seed by Spec.Bootstrap and assumes a single one); assert it
+	// rather than silently picking a victim from a cluster shaped wrongly.
+	if len(seeds) != 1 {
+		t.Fatalf("expected exactly 1 bootstrap seed, got %d: seeds=%v eligible=%v", len(seeds), seeds, eligible)
+	}
+	if len(eligible) == 0 {
+		t.Fatalf("no non-bootstrap member to corrupt; seeds=%v", seeds)
+	}
+	return eligible[0]
+}
+
+// etcdRestartState renders the member pod's etcd container restart count and
+// readiness for failure messages. The previous wording asserted the member was
+// "not yet past threshold" unconditionally, which sent the one real failure
+// this test has produced — a victim well past the threshold, held back by the
+// bootstrap gate instead — looking in entirely the wrong place.
+func etcdRestartState(ctx context.Context, member string) string {
+	pod, err := clientset.CoreV1().Pods(selfHealNamespace).Get(ctx, member, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Sprintf("pod state unknown: %v", err)
+	}
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.Name != "etcd" {
+			continue
+		}
+		return fmt.Sprintf("etcd container restarts=%d ready=%t", cs.RestartCount, cs.Ready)
+	}
+	return fmt.Sprintf("pod phase %s has no etcd container status", pod.Status.Phase)
 }
 
 // selfHealMembersErr is the error-tolerant form for use inside waitFor (a list


### PR DESCRIPTION
## Summary

`TestPVCMemberCrashLoopSelfHeal` fails roughly one run in three, for a reason
built into the test rather than into the operator. It picks its victim by index
and can land on the bootstrap seed, which is permanently excluded from the
self-heal path — so the test waits out its full 15-minute timeout for a deletion
that is by design never coming. This makes the victim selection explicit.

## Root cause

The test chose `original[0]`:

```go
original := selfHealMembers(ctx, t)   // kube.List → items sorted by name
victim := original[0]
```

`List` returns items name-sorted, and member names are apiserver-assigned random
suffixes (`etcd-p6bvx`, `etcd-v9kr8`, …). So `original[0]` is simply whichever
member's random suffix sorts first — the seed in about a third of runs.

The seed can never be self-healed. `etcdContainerStuck`'s caller gates on it:

```go
// controllers/etcdmember_controller.go:1058
if !member.Spec.Bootstrap &&
    member.Spec.Storage.Medium != lll.StorageMediumMemory &&
    etcdContainerStuck(pod) &&
    r.clusterHasQuorumWithout(ctx, member) {
```

and `Spec.Bootstrap` is set once, at member creation
(`controllers/etcdcluster_controller.go:463`), and never cleared. When the victim
is the seed the member is therefore never deleted, and the test burns its whole
15m budget before failing.

Observed across three consecutive E2E runs — the seed is the member that was
*not* added as a learner:

| Run | Members | Added as learner | Seed | Victim | Result |
|---|---|---|---|---|---|
| [30297109488](https://github.com/cozystack/etcd-operator/actions/runs/30297109488) (`fix/rebootstrap-when-every-member-lost`) | p6bvx, v9kr8, vtm7h | v9kr8, vtm7h | **p6bvx** | p6bvx | FAIL 940 s |
| [30302593237](https://github.com/cozystack/etcd-operator/actions/runs/30302593237) (`chore/codeowners`) | 9xf86, bst2x, fph75 | bst2x, fph75 | **9xf86** | 9xf86 | FAIL 940 s |
| [30342866014](https://github.com/cozystack/etcd-operator/actions/runs/30342866014) (`chore/codeowners`, re-run) | — | — | not the victim | h7gtw | PASS 250 s |

Note the second row: `chore/codeowners` is an 8-line change to
`.github/CODEOWNERS` with no Go code at all, and it failed identically. The
940.9 s duration in both failures is the 15m wait plus setup — the test never
had a chance, it just had to time out first.

## What changed

`selfHealReplaceableMember` picks a member with `Spec.Bootstrap == false`, so the
victim is always one the self-heal path can actually act on. It also asserts the
single-seed invariant (the cluster controller finds the seed by `Spec.Bootstrap`
and assumes exactly one) rather than silently selecting from a wrongly-shaped
cluster.

The timeout message is fixed too. It claimed:

```
victim "etcd-p6bvx" still present (crash-loop not yet past threshold)
```

In both failures the victim was well past the threshold — 7 restarts against
`dataLossRestartThreshold = 5` — and held back by the bootstrap gate instead. The
message sent the one real failure this test has produced looking in the wrong
place. It now reports the actual restart count and readiness:

```
victim "etcd-p6bvx" still present; etcd container restarts=7 ready=false
```

## Test coverage

No new test: this *is* the test, and the fix is in how it selects its subject.
The two behaviours involved are each covered where they belong —

- **seed is excluded from self-heal** (the contract that made the old selection
  flaky): `TestUpdateStatus_KeepsStuckBootstrapMember`, unit, already on `main`.
- **a replaceable member is self-healed** (the contract this E2E exists for):
  `TestPVCMemberCrashLoopSelfHeal`, which now reliably exercises it instead of
  covering it two runs out of three.

Verified locally: `go vet ./...`, `go vet -tags e2e ./test/e2e/...`, `gofmt -l`
clean, and `go test ./controllers/...` green. The E2E itself needs kind +
cert-manager + Kamaji and runs in CI here. Worth stating plainly: a single green
E2E run cannot by itself prove a 1-in-3 flake is gone — the argument is that the
victim is now selected by the very predicate the self-heal path gates on, so the
failing case is unreachable by construction rather than unlikely.

## Follow-up (not in this PR)

The flake incidentally documents a real gap: **a seed member whose data dir is
destroyed never recovers.** Quorum among the remaining members holds, but the
seed crash-loops forever — excluded from self-heal, with `Spec.Bootstrap` never
cleared and no condition saying so. Two candidate fixes, both narrow:

- clear `Spec.Bootstrap` once `status.clusterID` has latched — `docs/concepts.md:91`
  already asserts that after latching "the seed is, from that point on, just a
  regular member", which is not currently true of this field; or
- allow self-heal for the seed when `clusterHasQuorumWithout` holds, which is the
  condition that makes replacement safe in the first place.

Happy to open that separately once this lands.

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved self-healing validation by selecting a replaceable member instead of the bootstrap member.
  * Enhanced self-healing failure messages with the affected member’s etcd restart count and readiness diagnostics per attempt to simplify troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->