### PR TITLE
chore(codeowners): describe the file as review routing, not as authorship

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,9 @@
-# Ownership for this sub-project.
+# Review routing for this repository.
 #
 # The Cozystack maintainers are maintainers of every sub-project by default
-# (https://github.com/cozystack/cozystack/blob/main/MAINTAINERS.md). The
-# handles below are the people who own this repository day to day and whose
-# review is requested on every change here.
+# (https://github.com/cozystack/cozystack/blob/main/MAINTAINERS.md). The handles
+# below are the people whose review is requested on changes here. It is a
+# routing list, not a claim about who contributes most: some entries are here
+# because the area is theirs, others because the role carries the repository.
 
 * @lllamnyp @androndo


### PR DESCRIPTION
Follow-up to #344, which merged before this wording was corrected.

The header there says the handles below are "the people who own this repository day to day". That is not what the list is, and @lllamnyp pointed out the mismatch: some entries are on the list because the role carries the repository, not because the person has the most recent commits. Describing a routing list as authorship invites the reader to check it against the commit log and find a discrepancy that was never intended.

Same correction is going into the seven sibling pull requests that have not merged yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository review routing and ownership configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->